### PR TITLE
Move Atlassian Connect properties in separate class

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 coverage:
-  notify:
-    gitter:
+  status:
+    project:
       default:
-        url: "https://webhooks.gitter.im/e/73f5a024a677f026dd7b"
         threshold: 5%

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ add a the framework dependency to your project to turn it into an Atlassian Conn
 
 ### Creating a project from the seed project
 
-...
+The easiest way to get started is by cloning the [Atlassian Connect Play Seed](atlassian-connect-play-seed) 
+project.
+
 
 ### Modifying an existing project
 
@@ -70,4 +72,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+[atlassian-connect-play-seed]: https://github.com/toolsplus/atlassian-connect-play-seed
 [apache]: http://www.apache.org/licenses/LICENSE-2.0

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/actions/JwtAuthenticationActions.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/actions/JwtAuthenticationActions.scala
@@ -4,10 +4,17 @@ import cats.implicits._
 import com.google.inject.Inject
 import com.netaporter.uri.Uri
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
-import io.toolsplus.atlassian.connect.play.auth.jwt.exception.{JwtAuthenticationError, UnknownJwtIssuerError}
-import io.toolsplus.atlassian.connect.play.auth.jwt.{CanonicalPlayHttpRequest, JwtAuthenticationProvider, JwtCredentials}
+import io.toolsplus.atlassian.connect.play.auth.jwt.exception.{
+  JwtAuthenticationError,
+  UnknownJwtIssuerError
+}
+import io.toolsplus.atlassian.connect.play.auth.jwt.{
+  CanonicalPlayHttpRequest,
+  JwtAuthenticationProvider,
+  JwtCredentials
+}
 import io.toolsplus.atlassian.connect.play.controllers.routes
-import io.toolsplus.atlassian.connect.play.models.AddonProperties
+import io.toolsplus.atlassian.connect.play.models.AtlassianConnectProperties
 import play.api.Logger
 import play.api.http.HeaderNames
 import play.api.mvc.Results._
@@ -18,7 +25,7 @@ import scala.concurrent.Future
 
 class JwtAuthenticationActions @Inject()(
     jwtAuthenticationProvider: JwtAuthenticationProvider,
-    addonProperties: AddonProperties) {
+    connectProperties: AtlassianConnectProperties) {
 
   private val logger = Logger(classOf[JwtAuthenticationActions])
 
@@ -128,7 +135,7 @@ class JwtAuthenticationActions @Inject()(
       e match {
         case UnknownJwtIssuerError(_) =>
           (isInstalledLifecycleRequest(request) &&
-            addonProperties.allowReinstallMissingHost) ||
+            connectProperties.allowReinstallMissingHost) ||
             isUninstalledLifecycleRequest(request)
         case _ => false
       }

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/request/SelfAuthenticationTokenGenerator.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/request/SelfAuthenticationTokenGenerator.scala
@@ -5,7 +5,10 @@ import java.time.temporal.ChronoUnit
 
 import com.google.inject.Inject
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
-import io.toolsplus.atlassian.connect.play.models.AddonProperties
+import io.toolsplus.atlassian.connect.play.models.{
+  AddonProperties,
+  AtlassianConnectProperties
+}
 import io.toolsplus.atlassian.jwt.JwtSigningError
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 
@@ -14,12 +17,13 @@ import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
   * add-on to itself.
   */
 class SelfAuthenticationTokenGenerator @Inject()(
-    addonProperties: AddonProperties) {
+    addonProperties: AddonProperties,
+    connectProperties: AtlassianConnectProperties) {
 
   def createSelfAuthenticationToken(
       hostUser: AtlassianHostUser): Either[JwtSigningError, RawJwt] = {
     val expirationAfter = Duration.of(
-      addonProperties.selfAuthenticationExpirationTime,
+      connectProperties.selfAuthenticationExpirationTime,
       ChronoUnit.SECONDS)
     val jwt = new JwtBuilder(expirationAfter)
       .withIssuer(addonProperties.key)

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/AddonProperties.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/AddonProperties.scala
@@ -6,7 +6,7 @@ import io.toolsplus.atlassian.connect.play.api.models.Predefined.AddonKey
 import play.api.Configuration
 
 /** Class containing add-on properties such as add-on key, name, base url,
-  * etc. by reading them lazily from a Play configuration.
+  * etc.
   *
   * All values are read lazily from Play config files, hence they will be
   * cached for the lifetime of the Play app.
@@ -15,24 +15,15 @@ import play.api.Configuration
 class AddonProperties @Inject()(config: Configuration) {
 
   /** Key of this add-on. */
-  lazy val key: AddonKey = atlassianConnectConfig.getString("key").get
+  lazy val key: AddonKey = addonConfig.getString("key").get
 
   /** Name of this add-on. */
-  lazy val name: String = atlassianConnectConfig.getString("name").get
+  lazy val name: String = addonConfig.getString("name").get
 
   /** Base URL of this add-on. */
-  lazy val baseUrl: String = atlassianConnectConfig.getString("baseUrl").get
+  lazy val baseUrl: String = addonConfig.getString("baseUrl").get
 
-  /**
-    * Expiration time for self-authentication tokens in seconds.
-    */
-  lazy val selfAuthenticationExpirationTime: Int =
-    atlassianConnectConfig.getInt("selfAuthenticationExpirationTime").get
-
-  lazy val allowReinstallMissingHost: Boolean =
-    atlassianConnectConfig.getBoolean("allowReinstallMissingHost").get
-
-  private lazy val atlassianConnectConfig =
-    config.getConfig("atlassian.connect").get
+  private lazy val addonConfig =
+    config.getConfig("addon").get
 
 }

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/AtlassianConnectProperties.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/AtlassianConnectProperties.scala
@@ -1,0 +1,39 @@
+package io.toolsplus.atlassian.connect.play.models
+
+import javax.inject.{Inject, Singleton}
+
+import play.api.Configuration
+
+/** Class containing Atlassian Connect properties.
+  *
+  * These properties allow configuration of the framework's behaviour.
+  *
+  * All values are read lazily from Play config files, hence they will be
+  * cached for the lifetime of the Play app.
+  */
+@Singleton
+class AtlassianConnectProperties @Inject()(config: Configuration) {
+
+  /**
+    * Expiration time for self-authentication tokens in seconds.
+    */
+  lazy val selfAuthenticationExpirationTime: Int =
+    atlassianConnectConfig
+      .getInt("selfAuthenticationExpirationTime")
+      .getOrElse(900)
+
+  lazy val allowReinstallMissingHost: Boolean =
+    atlassianConnectConfig
+      .getBoolean("allowReinstallMissingHost")
+      .getOrElse(false)
+
+  /**
+    * Expiration time for JSON Web Tokens in seconds.
+    */
+  lazy val jwtExpirationTime: Int =
+    atlassianConnectConfig.getInt("jwtExpirationTime").getOrElse(180)
+
+  private lazy val atlassianConnectConfig =
+    config.getConfig("atlassian.connect").get
+
+}

--- a/modules/core/conf/reference.conf
+++ b/modules/core/conf/reference.conf
@@ -1,11 +1,15 @@
 atlassian.connect {
-  key = io.toolsplus.acplayscala
-  name = "Atlassian Connect Play Scala"
-  baseUrl = "localhost:9000"
-  baseUrl = ${?AC_BASE_URL}
+  jwtExpirationTime = 180
   selfAuthenticationExpirationTime = 900
   allowReinstallMissingHost = false
   allowReinstallMissingHost = ${?AC_ALLOW_REINSTALL_MISSING_HOST}
+}
+
+addon {
+  key = io.toolsplus.acplayscala
+  name = "Atlassian Connect Play"
+  baseUrl = "localhost:9000"
+  baseUrl = ${?AC_BASE_URL}
 }
 
 play {

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/JwtAuthenticationActionsSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/JwtAuthenticationActionsSpec.scala
@@ -4,12 +4,8 @@ import io.toolsplus.atlassian.connect.play.TestSpec
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
-import io.toolsplus.atlassian.connect.play.auth.jwt.{
-  CanonicalPlayHttpRequest,
-  JwtAuthenticationProvider,
-  JwtCredentials
-}
-import io.toolsplus.atlassian.connect.play.models.AddonProperties
+import io.toolsplus.atlassian.connect.play.auth.jwt.{CanonicalPlayHttpRequest, JwtAuthenticationProvider, JwtCredentials}
+import io.toolsplus.atlassian.connect.play.models.{AddonProperties, AtlassianConnectProperties}
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import org.scalacheck.Gen.alphaStr
 import org.scalacheck.Shrink
@@ -31,11 +27,12 @@ class JwtAuthenticationActionsSpec
 
   val hostRepository = mock[AtlassianHostRepository]
   val addonProperties = new AddonProperties(config)
+  val connectProperties = new AtlassianConnectProperties(config)
   val jwtAuthenticationProvider =
     new JwtAuthenticationProvider(hostRepository, addonProperties)
 
   val $ =
-    new JwtAuthenticationActions(jwtAuthenticationProvider, addonProperties)
+    new JwtAuthenticationActions(jwtAuthenticationProvider, connectProperties)
 
   "JwtAuthenticationActions" when {
 

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/request/SelfAuthenticationTokenGeneratorSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/request/SelfAuthenticationTokenGeneratorSpec.scala
@@ -1,7 +1,10 @@
 package io.toolsplus.atlassian.connect.play.auth.jwt.request
 
 import io.toolsplus.atlassian.connect.play.TestSpec
-import io.toolsplus.atlassian.connect.play.models.AddonProperties
+import io.toolsplus.atlassian.connect.play.models.{
+  AddonProperties,
+  AtlassianConnectProperties
+}
 import io.toolsplus.atlassian.jwt._
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import org.scalatest.Assertion
@@ -16,8 +19,10 @@ class SelfAuthenticationTokenGeneratorSpec
   val config = app.configuration
 
   val addonProperties = new AddonProperties(config)
+  val connectProperties = new AtlassianConnectProperties(config)
 
-  val $ = new SelfAuthenticationTokenGenerator(addonProperties)
+  val $ =
+    new SelfAuthenticationTokenGenerator(addonProperties, connectProperties)
 
   private val leewaySeconds = 30
 
@@ -32,7 +37,7 @@ class SelfAuthenticationTokenGeneratorSpec
 
           def assertion(jwt: Jwt) = {
             val expiry = jwt.claims.getExpirationTime.getTime / 1000
-            val expectedExpiry = now + addonProperties.selfAuthenticationExpirationTime
+            val expectedExpiry = now + connectProperties.selfAuthenticationExpirationTime
             expiry mustBe expectedExpiry +- leewaySeconds
           }
 


### PR DESCRIPTION
Split add-on properties into add-on properties and Atlassian Connect properties into separate classes. Atlassian Connect properties should live on their own and are separate from add-on properties. Default add-on properties are most likely overridden by the add-on, whereas Atlassian Connect properties are not.