### PR TITLE
Add Akka-based event bus that allows publishing of app events

### DIFF
--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/events/AppEvent.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/events/AppEvent.scala
@@ -1,0 +1,22 @@
+package io.toolsplus.atlassian.connect.play.api.events
+
+import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+
+/**
+  * The base event.
+  */
+trait AppEvent
+
+/**
+  * An event which will be published after a new host has been installed.
+  *
+  * @param host The newly installed Atlassian host.
+  */
+case class AppInstalledEvent(host: AtlassianHost) extends AppEvent
+
+/**
+  * An event which will be published after a host has uninstalled.
+  *
+  * @param host The uninstalled Atlassian host.
+  */
+case class AppUninstalledEvent(host: AtlassianHost) extends AppEvent

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/events/EventBus.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/events/EventBus.scala
@@ -1,0 +1,41 @@
+package io.toolsplus.atlassian.connect.play.events
+
+import akka.event.{ActorEventBus, SubchannelClassification}
+import akka.util.Subclassification
+import io.toolsplus.atlassian.connect.play.api.events.AppEvent
+
+/**
+  * Event bus implementation which uses a class based lookup classification.
+  */
+object EventBus extends ActorEventBus with SubchannelClassification {
+
+  override type Classifier = Class[_ <: AppEvent]
+  override type Event = AppEvent
+
+  /**
+    * Logic to form sub-class hierarchy
+    */
+  override protected implicit val subclassification
+    : Subclassification[Classifier] = new Subclassification[Classifier] {
+    def isEqual(x: Classifier, y: Classifier): Boolean = x == y
+    def isSubclass(x: Classifier, y: Classifier): Boolean =
+      y.isAssignableFrom(x)
+  }
+
+  /**
+    * Publishes the given Event to the given Subscriber.
+    *
+    * @param event The Event to publish.
+    * @param subscriber The Subscriber to which the Event should be published.
+    */
+  override protected def publish(event: Event, subscriber: Subscriber): Unit =
+    subscriber ! event
+
+  /**
+    * Returns the Classifier associated with the given Event.
+    *
+    * @param event The event for which the Classifier should be returned.
+    * @return The Classifier for the given Event.
+    */
+  override protected def classify(event: Event): Classifier = event.getClass
+}

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/events/EventBusSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/events/EventBusSpec.scala
@@ -1,0 +1,124 @@
+package io.toolsplus.atlassian.connect.play.events
+
+import akka.actor.{Actor, ActorSystem, Props}
+import akka.testkit.TestProbe
+import io.toolsplus.atlassian.connect.play.TestSpec
+import io.toolsplus.atlassian.connect.play.api.events.{AppEvent, AppInstalledEvent, AppUninstalledEvent}
+import io.toolsplus.atlassian.connect.play.generators.AtlassianHostGen
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class EventBusSpec extends TestSpec with GuiceOneAppPerSuite with AtlassianHostGen {
+
+  "Given an EventBus" when {
+
+    "accessing event bus" should {
+
+      "always be the same event bus" in {
+        val eventBus1 = EventBus
+        val eventBus2 = EventBus
+        eventBus1 must be theSameInstanceAs eventBus2
+      }
+
+    }
+
+    "receiving one ore more events" should {
+
+      "handle a subclass event" in new Context {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e => testProbe.ref ! e
+          }
+        }))
+
+        EventBus.subscribe(listener, classOf[AppEvent])
+
+        EventBus.publish(installedEvent)
+        testProbe.expectMsg(500 millis, installedEvent)
+
+        EventBus.publish(uninstalledEvent)
+        testProbe.expectMsg(500 millis, uninstalledEvent)
+      }
+
+      "handle an event" in new Context {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e @ AppInstalledEvent(_) => testProbe.ref ! e
+          }
+        }))
+
+        EventBus.subscribe(listener, classOf[AppInstalledEvent])
+
+        EventBus.publish(installedEvent)
+        testProbe.expectMsg(500 millis, installedEvent)
+      }
+
+      "handle multiple event" in new Context {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e @ AppInstalledEvent(_) => testProbe.ref ! e
+            case e @ AppUninstalledEvent(_) => testProbe.ref ! e
+          }
+        }))
+
+        EventBus.subscribe(listener, classOf[AppInstalledEvent])
+        EventBus.subscribe(listener, classOf[AppUninstalledEvent])
+        EventBus.publish(installedEvent)
+        EventBus.publish(uninstalledEvent)
+
+        testProbe.expectMsg(500 millis, installedEvent)
+        testProbe.expectMsg(500 millis, uninstalledEvent)
+      }
+
+      "differentiate between event classes" in new Context {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e @ AppInstalledEvent(_) => testProbe.ref ! e
+          }
+        }))
+
+        EventBus.subscribe(listener, classOf[AppUninstalledEvent])
+        EventBus.publish(uninstalledEvent)
+
+        testProbe.expectNoMessage(500 millis)
+      }
+
+      "not handle not subscribed events" in new Context {
+        val listener = system.actorOf(Props(new Actor {
+          def receive = {
+            case e @ AppInstalledEvent(_) => testProbe.ref ! e
+          }
+        }))
+
+        EventBus.publish(installedEvent)
+
+        testProbe.expectNoMessage(500 millis)
+      }
+
+    }
+
+  }
+
+  trait Context {
+
+    /**
+      * Play actor system.
+      */
+    lazy implicit val system = app.injector.instanceOf[ActorSystem]
+
+    /**
+      * Test probe.
+      */
+    lazy val testProbe = TestProbe()
+
+    lazy val someHost = atlassianHostGen.retryUntil(_ => true).sample.get
+
+    lazy val installedEvent = AppInstalledEvent(someHost)
+
+    lazy val uninstalledEvent = AppUninstalledEvent(someHost)
+
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,8 @@ object Dependencies {
     Library.scalaTestPlusPlay % "test",
     Library.scalaMock % "test",
     Library.scalaCheck % "test",
-    Library.atlassianJwtGenerators % "test"
+    Library.atlassianJwtGenerators % "test",
+    Library.akkaTestKit % "test"
   )
 }
 
@@ -25,6 +26,7 @@ object Version {
   val scalaTestPlusPlay = "3.1.2"
   val scalaMock = "3.6.0"
   val scalaCheck = "1.13.5"
+  val akkaTestKit = "2.5.9"
 }
 
 object Library {
@@ -39,4 +41,5 @@ object Library {
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % Version.scalaTestPlusPlay
   val scalaMock = "org.scalamock" %% "scalamock-scalatest-support" % Version.scalaMock
   val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
+  val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % Version.akkaTestKit
 }


### PR DESCRIPTION
- Add Akka-based event bus object
- Add base event and default app events to API
- Publish lifecycle events when app is installed or uninstalled