### PR TITLE
Extract AtlassianHost and AtlassianHostUser into traits

### DIFF
--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
@@ -8,44 +8,99 @@ import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostReposit
   *
   * During processing of a request from an Atlassian host, the details of the
   * host and of the user at the browser can be obtained from the [[AtlassianHostUser]].
-  *
-  * @param clientKey                Identifying key for the Atlassian product
-  *                                 instance that the add-on was installed into.
-  * @param key                      Add-on key that was installed into the
-  *                                 Atlassian Product, as it appears in your
-  *                                 add-on's descriptor.
-  * @param publicKey                Public key for this Atlassian product
-  *                                 instance.
-  * @param oauthClientId            OAuth 2.0 client ID for the add-on used
-  *                                 for OAuth 2.0 - JWT Bearer token
-  *                                 authorization grant type.
-  * @param sharedSecret             Secret to sign outgoing JWT tokens and
-  *                                 validate incoming JWT tokens. Only sent
-  *                                 on the installed event.
-  * @param serverVersion            Host product's version.
-  * @param pluginsVersion           Semver compliant version of Atlassian
-  *                                 Connect which is running on the host server.
-  * @param baseUrl                  URL prefix for this Atlassian product
-  *                                 instance.
-  * @param productType              Identifies the category of Atlassian
-  *                                 product, e.g. jira or confluence.
-  * @param description              Host product description.
-  * @param serviceEntitlementNumber Service entitlement number (SEN) is the
-  *                                 add-on license id. Only included during
-  *                                 installation of a paid add-on.
-  * @param installed                Indicates if the add-on is currently
-  *                                 installed on the host. Upon uninstallation,
-  *                                 the value of this flag will be set to false.
   */
-case class AtlassianHost(clientKey: ClientKey,
-                         key: String,
-                         publicKey: String,
-                         oauthClientId: Option[String],
-                         sharedSecret: String,
-                         serverVersion: String,
-                         pluginsVersion: String,
-                         baseUrl: String,
-                         productType: String,
-                         description: String,
-                         serviceEntitlementNumber: Option[String],
-                         installed: Boolean)
+trait AtlassianHost {
+
+  /** Identifying key for the Atlassian product
+    * instance that the add-on was installed into.
+    *
+    * @return Client key for this product instance.
+    */
+  def clientKey: ClientKey
+
+  /** Add-on key that was installed into the
+    * Atlassian product, as it appears in your
+    * add-on's descriptor.
+    *
+    * @return Add-on key for this add-on.
+    */
+  def key: String
+
+  /** Public key for this Atlassian product
+    * instance.
+    *
+    * @return Public key for this product instance.
+    */
+  def publicKey: String
+
+  /** OAuth 2.0 client ID for the add-on used
+    * for OAuth 2.0 - JWT Bearer token
+    * authorization grant type.
+    *
+    * @return OAuth 2.0 client id.
+    */
+  def oauthClientId: Option[String]
+
+  /** Secret to sign outgoing JWT tokens and
+    * validate incoming JWT tokens. Only sent
+    * on the installed event.
+    *
+    * @return Shared secret for this product instance.
+    */
+  def sharedSecret: String
+
+  /** Host product's version.
+    *
+    * @return Version of this product instance.
+    */
+  def serverVersion: String
+
+  /** Semver compliant version of Atlassian
+    * Connect which is running on the host server.
+    *
+    * @return Version of Atlassian Connect on this product instance.
+    */
+  def pluginsVersion: String
+
+  /** URL prefix for this Atlassian product
+    * instance.
+    *
+    * @return Base URL for this product instance.
+    */
+  def baseUrl: String
+
+  /** Identifies the category of Atlassian
+    * product, e.g. jira or confluence.
+    *
+    * @return Category of this product.
+    */
+  def productType: String
+
+  /** Host product description.
+    *
+    * @return Description of this product.
+    */
+  def description: String
+
+  /** Service entitlement number (SEN) is the
+    * add-on license id. Only included during
+    * installation of a paid add-on.
+    *
+    * @return Add-on license id if this is a paid add-on.
+    */
+  def serviceEntitlementNumber: Option[String]
+
+  /** Indicates if the add-on is currently
+    * installed on the host. Upon uninstallation,
+    * the value of this flag will be set to false.
+    *
+    * @return Installation status for this add-on.
+    */
+  def installed: Boolean
+
+  /** Uninstalls this host by setting the installed field to false.
+    *
+    * @return A new version of this host with the installed field set to false.
+    */
+  def uninstalled: AtlassianHost
+}

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHostUser.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHostUser.scala
@@ -3,11 +3,21 @@ package io.toolsplus.atlassian.connect.play.api.models
 /**
   * Authentication principal for requests coming from an Atlassian host
   * application in which the add-on is installed.
-  *
-  * @param host    Host from which the request originated.
-  * @param userKey Key of the user on whose behalf a request was made.
   */
-case class AtlassianHostUser(host: AtlassianHost, userKey: Option[String])
+trait AtlassianHostUser {
+
+  /** Host from which the request originated.
+    *
+    * @return Host associated with this operation.
+    */
+  def host: AtlassianHost
+
+  /** Key of the user on whose behalf a request was made.
+    *
+    * @return Key of the user associated with this request.
+    */
+  def userKey: Option[String]
+}
 
 object AtlassianHostUser {
 

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/StandardAtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/StandardAtlassianHost.scala
@@ -1,0 +1,21 @@
+package io.toolsplus.atlassian.connect.play.api.models
+
+import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
+
+/** Standard case class implementation of [[AtlassianHost]].
+  */
+case class StandardAtlassianHost(clientKey: ClientKey,
+                                 key: String,
+                                 publicKey: String,
+                                 oauthClientId: Option[String],
+                                 sharedSecret: String,
+                                 serverVersion: String,
+                                 pluginsVersion: String,
+                                 baseUrl: String,
+                                 productType: String,
+                                 description: String,
+                                 serviceEntitlementNumber: Option[String],
+                                 installed: Boolean) extends AtlassianHost {
+
+  override def uninstalled: AtlassianHost = copy(installed = false)
+}

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/StandardAtlassianHostUser.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/StandardAtlassianHostUser.scala
@@ -1,0 +1,8 @@
+package io.toolsplus.atlassian.connect.play.api.models
+
+/** Standard case class implementation of [[AtlassianHostUser]]
+  *
+  * @param host    Atlassian host associated with this operation.
+  * @param userKey Key of user associated with this operation.
+  */
+case class StandardAtlassianHostUser(host: AtlassianHost, userKey: Option[String]) extends AtlassianHostUser

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtAuthenticationProvider.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtAuthenticationProvider.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import com.google.inject.Inject
 import com.nimbusds.jwt.JWTClaimsSet
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.AddonKey
-import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, AtlassianHostUser}
+import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, AtlassianHostUser, StandardAtlassianHostUser}
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import io.toolsplus.atlassian.connect.play.models.AddonProperties
 import io.toolsplus.atlassian.jwt.{HttpRequestCanonicalizer, Jwt, JwtParser, JwtReader}
@@ -28,7 +28,7 @@ class JwtAuthenticationProvider @Inject()(
       clientKey <- extractClientKey(jwt).toEitherT[Future]
       host <- fetchAtlassianHost(clientKey)
       verifiedToken <- verifyJwt(jwtCredentials, host).toEitherT[Future]
-    } yield AtlassianHostUser(host, Option(verifiedToken.claims.getSubject))
+    } yield StandardAtlassianHostUser(host, Option(verifiedToken.claims.getSubject))
 
   private def parseJwt(rawJwt: String): Either[JwtAuthenticationError, Jwt] =
     JwtParser.parse(rawJwt).leftMap { e =>

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
@@ -1,6 +1,6 @@
 package io.toolsplus.atlassian.connect.play.models
 
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, StandardAtlassianHost}
 
 object Implicits {
 
@@ -15,7 +15,7 @@ object Implicits {
     */
   implicit def installedEventToAtlassianHost(
       implicit e: InstalledEvent): AtlassianHost =
-    AtlassianHost(
+    StandardAtlassianHost(
       e.clientKey,
       e.key,
       e.publicKey,

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/services/LifecycleService.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/services/LifecycleService.scala
@@ -122,16 +122,14 @@ class LifecycleService @Inject()(hostRepository: AtlassianHostRepository) {
                         maybeExistingHost: Option[AtlassianHost])
     : EitherT[Future, LifecycleError, AtlassianHost] = {
     maybeExistingHost match {
-      case Some(host) => {
+      case Some(host) =>
         logger.info(
           s"Saved uninstallation for host ${host.baseUrl} (${host.clientKey})")
-        EitherT.right(hostRepository.save(host.copy(installed = false)))
-      }
-      case None => {
+        EitherT.right(hostRepository.save(host.uninstalled))
+      case None =>
         logger.error(
           s"Received authenticated uninstall request but no installation for host ${uninstalledEvent.baseUrl} has been found. Assume the add-on has been removed.")
         EitherT.left(Future.successful(MissingAtlassianHostError))
-      }
     }
   }
 

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserActionSpec.scala
@@ -1,8 +1,8 @@
 package io.toolsplus.atlassian.connect.play.actions
 
 import io.toolsplus.atlassian.connect.play.TestSpec
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
+import io.toolsplus.atlassian.connect.play.api.models.StandardAtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import io.toolsplus.atlassian.connect.play.auth.jwt.{
   CanonicalPlayHttpRequest,
@@ -87,7 +87,7 @@ class AtlassianHostUserActionSpec
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
               val jwtRequest = JwtRequest(credentials, request)
-              val hostUser = AtlassianHostUser(host, Option(subject))
+              val hostUser = StandardAtlassianHostUser(host, Option(subject))
 
               (hostRepository
                 .findByClientKey(_: ClientKey)) expects host.clientKey returning Future

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
@@ -1,10 +1,8 @@
 package io.toolsplus.atlassian.connect.play.actions
 
-import javax.inject.Inject
-
 import io.toolsplus.atlassian.connect.play.TestSpec
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
+import io.toolsplus.atlassian.connect.play.api.models.StandardAtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import io.toolsplus.atlassian.connect.play.auth.jwt.{
   CanonicalPlayHttpRequest,
@@ -96,7 +94,7 @@ class OptionalAtlassianHostUserActionSpec
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
               val jwtRequest = MaybeJwtRequest(Some(credentials), request)
-              val hostUser = AtlassianHostUser(host, Option(subject))
+              val hostUser = StandardAtlassianHostUser(host, Option(subject))
 
               (hostRepository
                 .findByClientKey(_: ClientKey)) expects host.clientKey returning Future

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/JwtAuthenticationProviderSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/JwtAuthenticationProviderSpec.scala
@@ -1,8 +1,8 @@
 package io.toolsplus.atlassian.connect.play.auth.jwt
 
 import io.toolsplus.atlassian.connect.play.TestSpec
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
+import io.toolsplus.atlassian.connect.play.api.models.StandardAtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import io.toolsplus.atlassian.connect.play.models.AddonProperties
 import io.toolsplus.atlassian.jwt.generators.util.JwtTestHelper
@@ -130,7 +130,7 @@ class JwtAuthenticationProviderSpec extends TestSpec with GuiceOneAppPerSuite {
               val result = await {
                 jwtAuthenticationProvider.authenticate(credentials).value
               }
-              result mustBe Right(AtlassianHostUser(host, Option(subject)))
+              result mustBe Right(StandardAtlassianHostUser(host, Option(subject)))
           }
         }
       }
@@ -217,7 +217,7 @@ class JwtAuthenticationProviderSpec extends TestSpec with GuiceOneAppPerSuite {
             val result = await {
               jwtAuthenticationProvider.authenticate(credentials).value
             }
-            result mustBe Right(AtlassianHostUser(host, Option(subject)))
+            result mustBe Right(StandardAtlassianHostUser(host, Option(subject)))
           }
         }
       }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
@@ -1,20 +1,17 @@
 package io.toolsplus.atlassian.connect.play.generators
 
-import io.toolsplus.atlassian.connect.play.api.models.{
-  AtlassianHost,
-  AtlassianHostUser
-}
+import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHostUser, StandardAtlassianHost, StandardAtlassianHostUser}
 import org.scalacheck.Gen
 import org.scalacheck.Gen._
 
 trait AtlassianHostGen extends SecurityContextGen {
 
-  def atlassianHostGen: Gen[AtlassianHost] =
+  def atlassianHostGen: Gen[StandardAtlassianHost] =
     for {
       securityContext <- securityContextGen
       installed <- oneOf(true, false)
     } yield {
-      AtlassianHost(
+      StandardAtlassianHost(
         securityContext.clientKey,
         securityContext.key,
         securityContext.publicKey,
@@ -30,11 +27,11 @@ trait AtlassianHostGen extends SecurityContextGen {
       )
     }
 
-  def atlassianHostUserGen: Gen[AtlassianHostUser] =
+  def atlassianHostUserGen: Gen[StandardAtlassianHostUser] =
     for {
       atlassianHost <- atlassianHostGen
       userKey <- option(alphaStr)
-    } yield AtlassianHostUser(atlassianHost, userKey)
+    } yield StandardAtlassianHostUser(atlassianHost, userKey)
 
   def maybeAtlassianHostUserGen: Gen[Option[AtlassianHostUser]] =
     option(atlassianHostUserGen)

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/services/LifecycleServiceSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/services/LifecycleServiceSpec.scala
@@ -1,7 +1,7 @@
 package io.toolsplus.atlassian.connect.play.services
 
 import io.toolsplus.atlassian.connect.play.TestSpec
-import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, StandardAtlassianHost}
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import io.toolsplus.atlassian.connect.play.models.Implicits._
@@ -43,7 +43,7 @@ class LifecycleServiceSpec extends TestSpec {
             val installedEvent =
               someInstalledEvent.copy(clientKey = "clientKeyA")
             val hostUser = someHostUser.copy(
-              host = someHostUser.host.copy(clientKey = "clientKeyA"))
+              host = someHostUser.host.asInstanceOf[StandardAtlassianHost].copy(clientKey = "clientKeyA"))
             val newHost = installedEventToAtlassianHost(installedEvent)
 
             (hostRepository
@@ -63,7 +63,7 @@ class LifecycleServiceSpec extends TestSpec {
             val clientKeyMismatchEvent =
               installedEvent.copy(clientKey = "clientKeyA")
             val clientKeyMismatchHostUser =
-              hostUser.copy(host = hostUser.host.copy(clientKey = "clientKeyB"))
+              hostUser.copy(host = hostUser.host.asInstanceOf[StandardAtlassianHost].copy(clientKey = "clientKeyB"))
 
             val result = await {
               lifecycleService
@@ -80,7 +80,7 @@ class LifecycleServiceSpec extends TestSpec {
     "asked to install a security context from an unauthenticated request" should {
 
       "successfully install Atlassian host from security context" in {
-        forAll(installedEventGen) { (installedEvent) =>
+        forAll(installedEventGen) { installedEvent =>
           val newHost = installedEventToAtlassianHost(installedEvent)
 
           (hostRepository
@@ -124,7 +124,7 @@ class LifecycleServiceSpec extends TestSpec {
             val uninstalledEvent = genericEvent.copy(eventType = "uninstalled",
                                                      clientKey = clientKey)
             val installedHost =
-              someHostUser.host.copy(clientKey = clientKey, installed = true)
+              someHostUser.host.asInstanceOf[StandardAtlassianHost].copy(clientKey = clientKey, installed = true)
             val uninstalledHost = installedHost.copy(installed = false)
             val hostUser = someHostUser.copy(host = installedHost)
 
@@ -150,7 +150,7 @@ class LifecycleServiceSpec extends TestSpec {
             val uninstalledEvent = genericEvent.copy(eventType = "uninstalled",
                                                      clientKey = clientKey)
             val installedHost =
-              someHostUser.host.copy(clientKey = clientKey, installed = true)
+              someHostUser.host.asInstanceOf[StandardAtlassianHost].copy(clientKey = clientKey, installed = true)
             val hostUser = someHostUser.copy(host = installedHost)
 
             (hostRepository


### PR DESCRIPTION
Extract AtlassianHost and AtlassianHostUser into traits to allow override in add-ons

- Make AtlassianHost and AtlassianHostUser traits that can be overridden
- Provide standard case class implementations for AtlassianHost and AtlassianHostUser
- Update unit tests to work with standard implementations