### PR TITLE
Disallow AtlassianHost lookup by base URL

### DIFF
--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGenerator.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGenerator.scala
@@ -1,9 +1,5 @@
 package io.toolsplus.atlassian.connect.play.auth.jwt
 
-import java.net.URI
-import java.time.Duration
-import java.time.temporal.ChronoUnit
-
 import cats.syntax.either._
 import io.toolsplus.atlassian.connect.play.api.models.{AppProperties, AtlassianHost}
 import io.toolsplus.atlassian.connect.play.auth.jwt.JwtGenerator._
@@ -11,30 +7,18 @@ import io.toolsplus.atlassian.connect.play.models.AtlassianConnectProperties
 import io.toolsplus.atlassian.connect.play.ws.AtlassianHostUriResolver
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import io.toolsplus.atlassian.jwt.{HttpRequestCanonicalizer, JwtBuilder}
-import javax.inject.Inject
 import play.api.Logger
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import java.net.URI
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
 
 class JwtGenerator @Inject()(
     addonProperties: AppProperties,
-    atlassianConnectProperties: AtlassianConnectProperties,
-    hostUriResolver: AtlassianHostUriResolver) {
+    atlassianConnectProperties: AtlassianConnectProperties) {
 
   private val logger = Logger(classOf[JwtGenerator])
-
-  def createJwtToken(httpMethod: String,
-                     uri: URI): Future[Either[JwtGeneratorError, RawJwt]] = {
-    assertUriAbsolute(uri) match {
-      case Left(e) => Future.successful(Left(e))
-      case Right(_) =>
-        hostUriResolver.hostFromRequestUrl(uri).map {
-          case Some(host) => internalCreateJwtToken(httpMethod, uri, host)
-          case None       => Left(AtlassianHostNotFoundError(uri))
-        }
-    }
-  }
 
   def createJwtToken(httpMethod: String,
                      uri: URI,

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/ws/AtlassianHostUriResolver.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/ws/AtlassianHostUriResolver.scala
@@ -1,29 +1,9 @@
 package io.toolsplus.atlassian.connect.play.ws
 
-import java.net.URI
-
-import javax.inject.Inject
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
-import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 
-import scala.concurrent.Future
+import java.net.URI
 import scala.util.{Failure, Success, Try}
-
-/**
-  * A helper class for resolving URLs relative to the base URL of an AtlassianHost.
-  */
-class AtlassianHostUriResolver @Inject()(
-    hostRepository: AtlassianHostRepository) {
-
-  def hostFromRequestUrl(uri: URI): Future[Option[AtlassianHost]] = {
-    if (uri.isAbsolute) {
-      AtlassianHostUriResolver.baseUrl(uri) match {
-        case Some(url) => hostRepository.findByBaseUrl(url)
-        case None      => Future.successful(None)
-      }
-    } else Future.successful(None)
-  }
-}
 
 object AtlassianHostUriResolver {
 

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/ws/AtlassianHostUriResolverSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/ws/AtlassianHostUriResolverSpec.scala
@@ -1,18 +1,14 @@
 package io.toolsplus.atlassian.connect.play.ws
 
-import java.net.URI
-
 import io.toolsplus.atlassian.connect.play.TestSpec
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
 import org.scalacheck.Gen._
 
-import scala.concurrent.Future
+import java.net.URI
 
 class AtlassianHostUriResolverSpec extends TestSpec {
 
   val hostRepository: AtlassianHostRepository = mock[AtlassianHostRepository]
-
-  val hostUriResolver = new AtlassianHostUriResolver(hostRepository)
 
   "Given a AtlassianHostUriResolver" when {
 
@@ -26,56 +22,13 @@ class AtlassianHostUriResolverSpec extends TestSpec {
       }
 
       "return false if host base URL does not match given URI" in {
-        forAll(alphaStr.suchThat(!_.isEmpty), rootRelativePathGen, atlassianHostGen) { (hostName, path, host) =>
+        forAll(alphaStr.suchThat(_.nonEmpty), rootRelativePathGen, atlassianHostGen) { (hostName, path, host) =>
           val uri = URI.create(s"$hostName/$path")
           AtlassianHostUriResolver.isRequestToHost(uri, host) mustBe true
         }
       }
 
     }
-
-    "asked to look-up host for a given URI" should {
-
-      "successfully return matching host" in {
-        forAll(rootRelativePathGen, atlassianHostGen) { (path, host) =>
-          val uri = URI.create(s"${host.baseUrl}/$path")
-
-          (hostRepository
-            .findByBaseUrl(_: String)) expects host.baseUrl returning Future
-            .successful(Some(host))
-
-          val result = await {
-            hostUriResolver.hostFromRequestUrl(uri)
-          }
-          result mustBe Some(host)
-        }
-      }
-
-      "return None if no matching host can be found" in {
-        forAll(rootRelativePathGen, atlassianHostGen) { (path, host) =>
-          val uri = URI.create(s"${host.baseUrl}/$path")
-
-          (hostRepository
-            .findByBaseUrl(_: String)) expects host.baseUrl returning Future
-            .successful(None)
-
-          val result = await {
-            hostUriResolver.hostFromRequestUrl(uri)
-          }
-          result mustBe None
-        }
-      }
-
-      "return None if given URI is relative" in {
-        forAll(rootRelativePathGen) { path =>
-          await {
-            hostUriResolver.hostFromRequestUrl(URI.create(path))
-          } mustBe None
-        }
-      }
-
-    }
-
   }
 
 }


### PR DESCRIPTION
- Remove unused implementation to resolve AtlassianHosts by URL because this is generally considered problematic
- Remove the API to generate a JWT token without an AtlassianHost record (which falls back to host lookup by URL)

See:
- https://ecosystem.atlassian.net/browse/ACSPRING-121
- https://community.developer.atlassian.com/t/ensuring-your-atlassian-connect-app-handles-customer-site-imports/41874