### PR TITLE
Allow Context JWTs to be specified

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 val commonSettings = Seq(
   organization := "io.toolsplus",
-  scalaVersion := "2.13.2",
+  scalaVersion := "2.13.5",
   resolvers ++= Seq(
     "Typesafe repository releases" at "https://repo.typesafe.com/typesafe/releases/",
     "Bintary JCenter" at "https://jcenter.bintray.com"

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserAction.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserAction.scala
@@ -1,24 +1,27 @@
 package io.toolsplus.atlassian.connect.play.actions
 
-import javax.inject.Inject
-
 import cats.implicits._
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHostUser
-import io.toolsplus.atlassian.connect.play.auth.jwt.{
-  JwtAuthenticationProvider,
-  JwtCredentials
-}
+import io.toolsplus.atlassian.connect.play.auth.jwt._
 import play.api.mvc.Results.Unauthorized
 import play.api.mvc._
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 case class JwtRequest[A](credentials: JwtCredentials, request: Request[A])
     extends WrappedRequest[A](request)
 
+/**
+  * Play action refiner that extracts the JWT credentials from a request
+  *
+  * Note that this refiner will intercept the request and return an unauthorized
+  * result if no JWT credentials were found.
+  */
 class JwtActionRefiner @Inject()(
     implicit val executionContext: ExecutionContext)
     extends ActionRefiner[Request, JwtRequest] {
+
   override def refine[A](
       request: Request[A]): Future[Either[Result, JwtRequest[A]]] =
     JwtExtractor.extractJwt(request) match {
@@ -33,32 +36,62 @@ case class AtlassianHostUserRequest[A](hostUser: AtlassianHostUser,
                                        request: JwtRequest[A])
     extends WrappedRequest[A](request)
 
-class AtlassianHostUserActionRefiner @Inject()(
-    jwtAuthenticationProvider: JwtAuthenticationProvider)(
-    implicit val executionContext: ExecutionContext)
+case class AtlassianHostUserActionRefiner(
+    jwtAuthenticationProvider: JwtAuthenticationProvider,
+    qshProvider: QshProvider)(implicit val executionContext: ExecutionContext)
     extends ActionRefiner[JwtRequest, AtlassianHostUserRequest] {
   override def refine[A](request: JwtRequest[A])
     : Future[Either[Result, AtlassianHostUserRequest[A]]] = {
+    val expectedQsh = qshProvider match {
+      case ContextQshProvider => ContextQshProvider.qsh
+      case CanonicalHttpRequestQshProvider =>
+        CanonicalHttpRequestQshProvider.qsh(
+          request.credentials.canonicalHttpRequest)
+    }
     jwtAuthenticationProvider
-      .authenticate(request.credentials)
+      .authenticate(request.credentials, expectedQsh)
       .map(AtlassianHostUserRequest(_, request))
       .leftMap(e => Unauthorized(s"JWT validation failed: ${e.getMessage}"))
       .value
   }
 }
 
+class AtlassianHostUserActionRefinerFactory @Inject()(
+    jwtAuthenticationProvider: JwtAuthenticationProvider)(
+    implicit executionContext: ExecutionContext) {
+
+  def withQshFrom(qshProvider: QshProvider)
+    : AtlassianHostUserActionRefiner =
+    AtlassianHostUserActionRefiner(jwtAuthenticationProvider, qshProvider)
+}
+
 class AtlassianHostUserAction @Inject()(
-    val parser: BodyParsers.Default,
+    bodyParser: BodyParsers.Default,
     jwtActionRefiner: JwtActionRefiner,
-    atlassianHostUserActionRefiner: AtlassianHostUserActionRefiner)(
-    implicit val executionContext: ExecutionContext)
-    extends ActionBuilder[AtlassianHostUserRequest, AnyContent] {
-  override def invokeBlock[A](
-      request: Request[A],
-      block: AtlassianHostUserRequest[A] => Future[Result]) = {
-    (jwtActionRefiner andThen atlassianHostUserActionRefiner)
-      .invokeBlock(request, block)
-  }
+    atlassianHostUserActionRefinerFactory: AtlassianHostUserActionRefinerFactory)(
+    implicit executionCtx: ExecutionContext) {
+
+  /**
+    * Creates an action builder that validates JWT authenticated requests and verifies the
+    * query string hash claim against the provided query string hash provider.
+    *
+    * @param qshProvider Query string hash provider that specifies what kind of QSH the qsh claim contains
+    * @return Play action for JWT validated requests
+    */
+  def withQshFrom(qshProvider: QshProvider)
+    : ActionBuilder[AtlassianHostUserRequest, AnyContent] =
+    new ActionBuilder[AtlassianHostUserRequest, AnyContent] {
+      override val parser: BodyParsers.Default = bodyParser
+      override val executionContext: ExecutionContext = executionCtx
+      override def invokeBlock[A](
+          request: Request[A],
+          block: AtlassianHostUserRequest[A] => Future[Result])
+        : Future[Result] = {
+        (jwtActionRefiner andThen atlassianHostUserActionRefinerFactory
+          .withQshFrom(qshProvider))
+          .invokeBlock(request, block)
+      }
+    }
 
   object Implicits {
 

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/actions/JwtExtractor.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/actions/JwtExtractor.scala
@@ -18,12 +18,12 @@ object JwtExtractor {
     request.headers
       .get(HeaderNames.AUTHORIZATION)
       .filter(header =>
-        !header.isEmpty && header.startsWith(AuthorizationHeaderPrefix))
+        header.nonEmpty && header.startsWith(AuthorizationHeaderPrefix))
       .map(_.substring(AuthorizationHeaderPrefix.length).trim)
   }
 
   private def extractJwtFromParameter[A](request: Request[A]): Option[String] = {
-    request.getQueryString(QueryParameterName).filter(!_.isEmpty)
+    request.getQueryString(QueryParameterName).filter(_.nonEmpty)
   }
 
   private[actions] val AuthorizationHeaderPrefix = "JWT "

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGenerator.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGenerator.scala
@@ -33,8 +33,9 @@ class JwtGenerator @Inject()(
       httpMethod: String,
       uri: URI,
       host: AtlassianHost): Either[JwtGeneratorError, RawJwt] = {
+    val hostContextPath = Option(URI.create(host.baseUrl).getPath)
     val canonicalHttpRequest =
-      CanonicalUriHttpRequest(httpMethod, uri, host.baseUrl)
+      CanonicalUriHttpRequest(httpMethod, uri, hostContextPath)
     logger.trace(
       s"Generating JWT with canonical request: $canonicalHttpRequest")
     val queryHash =

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/QshProvider.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/QshProvider.scala
@@ -1,0 +1,24 @@
+package io.toolsplus.atlassian.connect.play.auth.jwt
+
+import io.toolsplus.atlassian.jwt.HttpRequestCanonicalizer
+import io.toolsplus.atlassian.jwt.api.CanonicalHttpRequest
+
+/**
+  * Base trait for Query string hash providers
+  */
+sealed trait QshProvider
+
+/**
+  * Query string hash provider that returns a static value of "context-qsh" for the query string hash.
+  */
+case object ContextQshProvider extends QshProvider {
+  def qsh: String = "context-qsh"
+}
+
+/**
+  * Query string hash provider that computes the QSH from the given canonical HTTP request representation.
+  */
+case object CanonicalHttpRequestQshProvider extends QshProvider {
+  def qsh(canonicalHttpRequest: CanonicalHttpRequest): String = HttpRequestCanonicalizer.computeCanonicalRequestHash(
+    canonicalHttpRequest)
+}

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/controllers/LifecycleController.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/controllers/LifecycleController.scala
@@ -2,11 +2,9 @@ package io.toolsplus.atlassian.connect.play.controllers
 
 import com.google.inject.Inject
 import io.circe.generic.auto._
-import io.toolsplus.atlassian.connect.play.actions.{
-  AtlassianHostUserAction,
-  OptionalAtlassianHostUserAction
-}
+import io.toolsplus.atlassian.connect.play.actions.{AtlassianHostUserAction, OptionalAtlassianHostUserAction}
 import io.toolsplus.atlassian.connect.play.api.models.AppProperties
+import io.toolsplus.atlassian.connect.play.auth.jwt.CanonicalHttpRequestQshProvider
 import io.toolsplus.atlassian.connect.play.models.{GenericEvent, InstalledEvent}
 import io.toolsplus.atlassian.connect.play.services._
 import play.api.libs.circe.Circe
@@ -31,7 +29,7 @@ class LifecycleController @Inject()(
   import optionalAtlassianHostUserAction.Implicits._
 
   def installed = {
-    optionalAtlassianHostUserAction.async(circe.json[InstalledEvent]) {
+    optionalAtlassianHostUserAction.withQshFrom(CanonicalHttpRequestQshProvider).async(circe.json[InstalledEvent]) {
       implicit request =>
         lifecycleService.installed(request.body).value map {
           case Right(_) => Ok
@@ -49,7 +47,7 @@ class LifecycleController @Inject()(
   }
 
   def uninstalled =
-    atlassianHostUserAction.async(circe.json[GenericEvent]) {
+    atlassianHostUserAction.withQshFrom(CanonicalHttpRequestQshProvider).async(circe.json[GenericEvent]) {
       implicit request =>
         lifecycleService.uninstalled(request.body).value map {
           case Right(_) => NoContent

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/AtlassianHostUserActionSpec.scala
@@ -4,18 +4,13 @@ import io.toolsplus.atlassian.connect.play.TestSpec
 import io.toolsplus.atlassian.connect.play.api.models.DefaultAtlassianHostUser
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository
-import io.toolsplus.atlassian.connect.play.auth.jwt.{
-  CanonicalHttpRequestQshProvider,
-  CanonicalPlayHttpRequest,
-  ContextQshProvider,
-  JwtAuthenticationProvider,
-  JwtCredentials
-}
+import io.toolsplus.atlassian.connect.play.auth.jwt.{CanonicalHttpRequestQshProvider, CanonicalPlayHttpRequest, ContextQshProvider, JwtAuthenticationProvider, JwtCredentials}
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import org.scalacheck.Gen.alphaStr
 import org.scalacheck.Shrink
 import org.scalatest.EitherValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.http.HeaderNames
 import play.api.mvc.BodyParsers
 import play.api.mvc.Results.Unauthorized
@@ -28,11 +23,11 @@ class AtlassianHostUserActionSpec
     with GuiceOneAppPerSuite
     with EitherValues {
 
-  val config = app.configuration
+  val config: Configuration = app.configuration
 
-  val parser = app.injector.instanceOf[BodyParsers.Default]
+  val parser: BodyParsers.Default = app.injector.instanceOf[BodyParsers.Default]
 
-  val hostRepository = mock[AtlassianHostRepository]
+  val hostRepository: AtlassianHostRepository = mock[AtlassianHostRepository]
   val jwtAuthenticationProvider =
     new JwtAuthenticationProvider(hostRepository)
 
@@ -50,7 +45,7 @@ class AtlassianHostUserActionSpec
     "refining a standard Request" should {
 
       "successfully refine request to JwtRequest" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(signedJwtStringGen(), playRequestGen) { (rawJwt, request) =>
           val jwtHeader = HeaderNames.AUTHORIZATION -> s"${JwtExtractor.AuthorizationHeaderPrefix} $rawJwt"
           val jwtRequest = request.withHeaders(jwtHeader)
@@ -64,7 +59,7 @@ class AtlassianHostUserActionSpec
       }
 
       "fail to refine request if it does not contain a token" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen) { request =>
           val result = await {
             jwtActionRefiner.refine(request)
@@ -82,7 +77,7 @@ class AtlassianHostUserActionSpec
     "refining a JwtRequest" should {
 
       "successfully refine JwtRequest with context QSH to AtlassianHostUserRequest" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
@@ -106,7 +101,7 @@ class AtlassianHostUserActionSpec
       }
 
       "successfully refine JwtRequest with HTTP request QSH to AtlassianHostUserRequest" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
@@ -130,7 +125,7 @@ class AtlassianHostUserActionSpec
       }
 
       "fail to refine request if authentication fails" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/JwtExtractorSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/JwtExtractorSpec.scala
@@ -16,7 +16,7 @@ class JwtExtractorSpec extends TestSpec {
     "trying to extract JWT from request " should {
 
       "successfully extract token from request header" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(signedJwtStringGen(), playRequestGen) { (rawJwt, request) =>
           val jwtHeader = HeaderNames.AUTHORIZATION -> s"${JwtExtractor.AuthorizationHeaderPrefix} $rawJwt"
           val jwtRequest = request.withHeaders(jwtHeader)
@@ -27,7 +27,7 @@ class JwtExtractorSpec extends TestSpec {
       }
 
       "successfully extract token from request query string" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(signedJwtStringGen()) { rawJwt =>
           val jwtQueryParams = Map("jwt" -> Seq(rawJwt))
           forAll(playRequestGen(jwtQueryParams)) { request =>
@@ -39,7 +39,7 @@ class JwtExtractorSpec extends TestSpec {
       }
 
       "return None if request does not contain a token" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen) { request =>
           JwtExtractor.extractJwt(request) mustBe None
         }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
@@ -11,6 +11,7 @@ import org.scalacheck.Gen.alphaStr
 import org.scalacheck.Shrink
 import org.scalatest.EitherValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
 import play.api.http.HeaderNames
 import play.api.mvc.BodyParsers
 import play.api.mvc.Results.Unauthorized
@@ -25,11 +26,11 @@ class OptionalAtlassianHostUserActionSpec
     with GuiceOneAppPerSuite
     with EitherValues {
 
-  val config = app.configuration
+  val config: Configuration = app.configuration
 
-  val parser = app.injector.instanceOf[BodyParsers.Default]
+  val parser: BodyParsers.Default = app.injector.instanceOf[BodyParsers.Default]
 
-  val hostRepository = mock[AtlassianHostRepository]
+  val hostRepository: AtlassianHostRepository = mock[AtlassianHostRepository]
   val connectProperties = new AtlassianConnectProperties(config)
   val jwtAuthenticationProvider =
     new JwtAuthenticationProvider(hostRepository)
@@ -50,7 +51,7 @@ class OptionalAtlassianHostUserActionSpec
     "refining a standard Request" should {
 
       "successfully refine request to MaybeJwtRequest including token" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(signedJwtStringGen(), playRequestGen) { (rawJwt, request) =>
           val jwtHeader = HeaderNames.AUTHORIZATION -> s"${JwtExtractor.AuthorizationHeaderPrefix} $rawJwt"
           val jwtRequest = request.withHeaders(jwtHeader)
@@ -64,7 +65,7 @@ class OptionalAtlassianHostUserActionSpec
       }
 
       "successfully refine request to MaybeJwtRequest without a token" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen) { request =>
           val result = await {
             maybeJwtActionTransformer.refine(request)
@@ -82,7 +83,7 @@ class OptionalAtlassianHostUserActionSpec
     "refining a MaybeJwtRequest" should {
 
       "successfully refine request with context QSH to MaybeAtlassianHostUserRequest" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
@@ -106,7 +107,7 @@ class OptionalAtlassianHostUserActionSpec
       }
 
       "successfully refine request with HTTP request QSH to MaybeAtlassianHostUserRequest" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>
@@ -130,7 +131,7 @@ class OptionalAtlassianHostUserActionSpec
       }
 
       "successfully refine request for an unknown host if it is an 'uninstalled' request" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(atlassianHostGen, alphaStr) { (host, subject) =>
           forAll(jwtCredentialsGen(host, subject)) { credentials =>
             val jwtHeader = HeaderNames.AUTHORIZATION -> s"${JwtExtractor.AuthorizationHeaderPrefix} ${credentials.rawJwt}"
@@ -153,7 +154,7 @@ class OptionalAtlassianHostUserActionSpec
       }
 
       "successfully refine request to MaybeAtlassianHostUserRequest without a token" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen) { request =>
           val jwtRequest = MaybeJwtRequest(None, request)
 
@@ -167,7 +168,7 @@ class OptionalAtlassianHostUserActionSpec
       }
 
       "fail to refine request if authentication fails" in {
-        implicit val rawJwtNoShrink = Shrink[RawJwt](_ => Stream.empty)
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
             forAll(jwtCredentialsGen(host, subject)) { credentials =>

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/OptionalAtlassianHostUserActionSpec.scala
@@ -15,7 +15,9 @@ import play.api.Configuration
 import play.api.http.HeaderNames
 import play.api.mvc.BodyParsers
 import play.api.mvc.Results.Unauthorized
+import play.api.http.Status.UNAUTHORIZED
 import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsString, status}
 import play.test.Helpers
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -82,12 +84,18 @@ class OptionalAtlassianHostUserActionSpec
 
     "refining a MaybeJwtRequest" should {
 
-      "successfully refine request with context QSH to MaybeAtlassianHostUserRequest" in {
+      "successfully refine JwtRequest with context QSH claim to MaybeAtlassianHostUserRequest" in {
         implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
-            forAll(jwtCredentialsGen(host, subject)) { credentials =>
-              val jwtRequest = MaybeJwtRequest(Some(credentials), request)
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val qsh = ContextQshProvider.qsh
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject, "qsh" -> qsh)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)),
+                                request)
               val hostUser =
                 DefaultAtlassianHostUser(host, None, Option(subject))
 
@@ -106,12 +114,83 @@ class OptionalAtlassianHostUserActionSpec
         }
       }
 
-      "successfully refine request with HTTP request QSH to MaybeAtlassianHostUserRequest" in {
+      /*
+       * This is to test that the JwtReader accepts JWT tokens without any QSH claim
+       *
+       * At the latest after Atlassian has rolled out the change to include qsh in all JWTs (in particular context JWTs)
+       * atlassian-jwt should be updated to not accept JWTs without qsh claims and this test should then fail.
+       *
+       * https://community.developer.atlassian.com/t/advance-notice-of-vulnerability-bypass-connect-app-qsh-verification-via-context-jwts/46659/10?u=tbinna
+       */
+      "successfully refine JwtRequest with without any QSH claim and ContextQshProvider to MaybeAtlassianHostUserRequest" in {
         implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
         forAll(playRequestGen, atlassianHostGen, alphaStr) {
           (request, host, subject) =>
-            forAll(jwtCredentialsGen(host, subject)) { credentials =>
-              val jwtRequest = MaybeJwtRequest(Some(credentials), request)
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)),
+                                request)
+              val hostUser =
+                DefaultAtlassianHostUser(host, None, Option(subject))
+
+              (hostRepository
+                .findByClientKey(_: ClientKey)) expects host.clientKey returning Future
+                .successful(Some(host))
+
+              val result = await {
+                maybeAtlassianHostUserActionRefinerFactory
+                  .withQshFrom(ContextQshProvider)
+                  .refine(jwtRequest)
+              }
+              result mustBe Right(
+                MaybeAtlassianHostUserRequest(Some(hostUser), jwtRequest))
+            }
+        }
+      }
+
+      "fail to refine JwtRequest with HTTP request QSH claim and ContextQshProvider" in {
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
+        forAll(playRequestGen, atlassianHostGen, alphaStr) {
+          (request, host, subject) =>
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val qsh = CanonicalHttpRequestQshProvider.qsh(canonicalHttpRequest)
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject, "qsh" -> qsh)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)),
+                                request)
+
+              (hostRepository
+                .findByClientKey(_: ClientKey)) expects host.clientKey returning Future
+                .successful(Some(host))
+
+              val result =
+                maybeAtlassianHostUserActionRefinerFactory
+                  .withQshFrom(ContextQshProvider)
+                  .refine(jwtRequest)
+
+              status(result.map(_.left.value)) mustBe UNAUTHORIZED
+              contentAsString(result.map(_.left.value)) startsWith "JWT validation failed"
+            }
+        }
+      }
+
+      "successfully refine JwtRequest with HTTP request QSH to MaybeAtlassianHostUserRequest" in {
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
+        forAll(playRequestGen, atlassianHostGen, alphaStr) {
+          (request, host, subject) =>
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val qsh = CanonicalHttpRequestQshProvider.qsh(canonicalHttpRequest)
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject, "qsh" -> qsh)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)),
+                                request)
               val hostUser =
                 DefaultAtlassianHostUser(host, None, Option(subject))
 
@@ -126,6 +205,69 @@ class OptionalAtlassianHostUserActionSpec
               }
               result mustBe Right(
                 MaybeAtlassianHostUserRequest(Some(hostUser), jwtRequest))
+            }
+        }
+      }
+
+      /*
+       * This is to test that the JwtReader accepts JWT tokens without any QSH claim
+       *
+       * At the latest after Atlassian has rolled out the change to include qsh in all JWTs (in particular context JWTs)
+       * atlassian-jwt should be updated to not accept JWTs without qsh claims and this test should then fail.
+       *
+       * https://community.developer.atlassian.com/t/advance-notice-of-vulnerability-bypass-connect-app-qsh-verification-via-context-jwts/46659/10?u=tbinna
+       */
+      "successfully refine JwtRequest with without any QSH claim and CanonicalHttpRequestQshProvider to MaybeAtlassianHostUserRequest" in {
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
+        forAll(playRequestGen, atlassianHostGen, alphaStr) {
+          (request, host, subject) =>
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)), request)
+              val hostUser =
+                DefaultAtlassianHostUser(host, None, Option(subject))
+
+              (hostRepository
+                .findByClientKey(_: ClientKey)) expects host.clientKey returning Future
+                .successful(Some(host))
+
+              val result = await {
+                maybeAtlassianHostUserActionRefinerFactory
+                  .withQshFrom(CanonicalHttpRequestQshProvider)
+                  .refine(jwtRequest)
+              }
+              result mustBe Right(
+                MaybeAtlassianHostUserRequest(Some(hostUser), jwtRequest))
+            }
+        }
+      }
+
+      "fail to refine JwtRequest with context QSH claim and CanonicalHttpRequestQshProvider" in {
+        implicit val rawJwtNoShrink: Shrink[RawJwt] = Shrink.shrinkAny
+        forAll(playRequestGen, atlassianHostGen, alphaStr) {
+          (request, host, subject) =>
+            val canonicalHttpRequest = CanonicalPlayHttpRequest(request)
+            val qsh = ContextQshProvider.qsh
+            val customClaims =
+              Seq("iss" -> host.clientKey, "sub" -> subject, "qsh" -> qsh)
+            forAll(signedJwtStringGen(host.sharedSecret, customClaims)) { jwt =>
+              val jwtRequest =
+                MaybeJwtRequest(Some(JwtCredentials(jwt, canonicalHttpRequest)), request)
+
+              (hostRepository
+                .findByClientKey(_: ClientKey)) expects host.clientKey returning Future
+                .successful(Some(host))
+
+              val result =
+                maybeAtlassianHostUserActionRefinerFactory
+                  .withQshFrom(CanonicalHttpRequestQshProvider)
+                  .refine(jwtRequest)
+
+              status(result.map(_.left.value)) mustBe UNAUTHORIZED
+              contentAsString(result.map(_.left.value)) startsWith "JWT validation failed"
             }
         }
       }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGeneratorSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/JwtGeneratorSpec.scala
@@ -71,10 +71,11 @@ class JwtGeneratorSpec extends TestSpec with GuiceOneAppPerSuite {
         forAll(methodGen, rootRelativePathGen, atlassianHostGen) {
           (method, relativePath, host) =>
             val absoluteUri = absoluteHostUri(host.baseUrl, relativePath)
+            val hostContextPath = Option(URI.create(host.baseUrl).getPath)
             jwtGenerator.createJwtToken(method, absoluteUri, host) match {
               case Right(rawJwt) =>
                 val request =
-                  CanonicalUriHttpRequest(method, absoluteUri, host.baseUrl)
+                  CanonicalUriHttpRequest(method, absoluteUri, hostContextPath)
                 val qsh =
                   HttpRequestCanonicalizer.computeCanonicalRequestHash(request)
                 JwtReader(host.sharedSecret).readAndVerify(rawJwt, qsh) match {

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/PlayRequestGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/PlayRequestGen.scala
@@ -11,7 +11,8 @@ trait PlayRequestGen extends HttpGen {
     for {
       method <- methodGen
       query <- queryStringGen
-      uri <- listOf(alphaNumStr.suchThat(!_.isEmpty))
+      n <- chooseNum(1, 5)
+      uri <- listOfN(n, alphaNumStr.suchThat(_.nonEmpty))
         .map(_.mkString("/"))
     } yield FakeRequest(method, s"$uri?$query")
 
@@ -21,7 +22,8 @@ trait PlayRequestGen extends HttpGen {
     for {
       method <- methodGen
       query <- queryStringGen
-      uri <- listOf(alphaNumStr.suchThat(!_.isEmpty))
+      n <- chooseNum(1, 5)
+      uri <- listOfN(n, alphaNumStr.suchThat(_.nonEmpty))
         .map(_.mkString("/"))
     } yield FakeRequest(method, s"$uri?$query&$additionalQuery")
   }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
@@ -34,16 +34,18 @@ trait SecurityContextGen {
 
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
+  def hostBaseUrlGen: Gen[String] =  alphaStr.suchThat(_.nonEmpty).map(hostName => s"https://$hostName.atlassian.net")
+
   def securityContextGen: Gen[SecurityContext]=
     for {
       key <- alphaStr
       clientKey <- clientKeyGen
       publicKey <- alphaNumStr
       oauthClientId <- option(alphaNumStr)
-      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && !s.isEmpty)
+      sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       serverVersion <- numStr
       pluginsVersion <- pluginVersionGen
-      baseUrl <- alphaStr.suchThat(!_.isEmpty)
+      baseUrl <- hostBaseUrlGen
       productType <- productTypeGen
       description <- alphaStr
       serviceEntitlementNumber <- option(numStr)
@@ -55,7 +57,7 @@ trait SecurityContextGen {
        sharedSecret,
        serverVersion,
        pluginsVersion,
-       s"https://$baseUrl.atlassian.net",
+        baseUrl,
        productType,
        description,
        serviceEntitlementNumber)

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/ws/AtlassianConnectHttpClientSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/ws/AtlassianConnectHttpClientSpec.scala
@@ -40,7 +40,7 @@ class AtlassianConnectHttpClientSpec extends TestSpec with GuiceOneAppPerSuite {
         }
 
       "set correct authorization and user-agent request headers" in {
-        implicit val doNotShrinkStrings = Shrink[String](_ => Stream.empty)
+        implicit val doNotShrinkStrings: Shrink[String] = Shrink.shrinkAny
         forAll(atlassianHostGen) { host =>
           val path = "foo"
           forAll(jwtCredentialsGen(host, subject = "bar")) { credentials =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
- Update JwtAuthenticationProvider to accept the expected query string hash (QSH)
- Update AtlassianHostUserAction.scala and OptionalAtlassianHostUserAction.scala to force the user to specify either QSH validation via canonical HTTP request, or via static context QSH value
-  Update LifecycleController.scala to use canonical HTTP request QSH validation
-  Update tests