### PR TITLE
Update lifecycle payload with new fields and remove deprecated fields

### DIFF
--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
@@ -2,104 +2,130 @@ package io.toolsplus.atlassian.connect.play.api.models
 
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 
-/** An Atlassian host in which the add-on is or has been installed. Hosts are
-  * stored in AtlassianHostRepository.
-  *
-  * During processing of a request from an Atlassian host, the details of the
-  * host and of the user at the browser can be obtained from the [[AtlassianHostUser]].
-  */
+/** An Atlassian host in which the app is or has been installed. Hosts are
+ * stored in AtlassianHostRepository.
+ *
+ * During processing of a request from an Atlassian host, the details of the
+ * host and of the user at the browser can be obtained from the [[AtlassianHostUser]].
+ *
+ * @see https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/#lifecycle-http-request-payload
+ */
 trait AtlassianHost {
 
   /** Identifying key for the Atlassian product
-    * instance that the add-on was installed into.
-    *
-    * @return Client key for this product instance.
-    */
+   * instance that the app was installed into.
+   *
+   * @return Client key for this product instance.
+   */
   def clientKey: ClientKey
 
-  /** Add-on key that was installed into the
-    * Atlassian product, as it appears in your
-    * add-on's descriptor.
-    *
-    * @return Add-on key for this add-on.
-    */
+  /** App key that was installed into the
+   * Atlassian product, as it appears in your
+   * app's descriptor.
+   *
+   * @return App key for this app.
+   */
   def key: String
 
-  /** Public key for this Atlassian product
-    * instance.
-    *
-    * @return Public key for this product instance.
-    */
-  def publicKey: String
-
-  /** OAuth 2.0 client ID for the add-on used
-    * for OAuth 2.0 - JWT Bearer token
-    * authorization grant type.
-    *
-    * @return OAuth 2.0 client id.
-    */
+  /** OAuth 2.0 client ID for the app used
+   * for OAuth 2.0 - JWT Bearer token
+   * authorization grant type.
+   *
+   * @return OAuth 2.0 client id.
+   */
   def oauthClientId: Option[String]
 
   /** Secret to sign outgoing JWT tokens and
-    * validate incoming JWT tokens. Only sent
-    * on the installed event.
-    *
-    * @return Shared secret for this product instance.
-    */
+   * validate incoming JWT tokens. Only sent
+   * on the installed event.
+   *
+   * @return Shared secret for this product instance.
+   */
   def sharedSecret: String
 
-  /** Host product's version.
-    *
-    * @return Version of this product instance.
-    */
-  def serverVersion: String
-
-  /** Semver compliant version of Atlassian
-    * Connect which is running on the host server.
-    *
-    * @return Version of Atlassian Connect on this product instance.
-    */
-  def pluginsVersion: String
-
   /** URL prefix for this Atlassian product
-    * instance.
-    *
-    * @return Base URL for this product instance.
-    */
+   * instance.
+   *
+   * @return Base URL for this product instance.
+   */
   def baseUrl: String
 
+  /**
+   * If the Atlassian product instance has an associated custom domain, this is the URL through which users will
+   * access the product. Any links which an app renders server-side should use this as the prefix of the link.
+   * This ensures links are rendered in the same context as the remainder of the user's site. If a custom domain
+   * is not configured, this field will still be present but will be the same as the baseUrl.
+   *
+   * Note that API requests from your app should always use the baseUrl value.
+   *
+   * @return Custom domain URL if configured, app's base URL otherwise.
+   */
+  def displayUrl: String
+
+  /**
+   * If the Atlassian product instance has an associated custom domain for Jira Service Desk functionality, this is
+   * the URL for the Jira Service Desk Help Center. Any related links which an app renders server-side should use this
+   * as the prefix of the link.
+   * This ensures links are rendered in the same context as the user's Jira Service Desk. If a custom domain is not
+   * configured, this field will still be present but will be the same as the baseUrl.
+   *
+   * Note that API requests from your App should always use the baseUrl value.
+   *
+   * @return Custom domain URL for Jira Service Desk if configured, app's base URL otherwise.
+   */
+  def displayUrlServicedeskHelpCenter: String
+
   /** Identifies the category of Atlassian
-    * product, e.g. jira or confluence.
-    *
-    * @return Category of this product.
-    */
+   * product, e.g. jira or confluence.
+   *
+   * @return Category of this product.
+   */
   def productType: String
 
   /** Host product description.
-    *
-    * @return Description of this product.
-    */
+   *
+   * @return Description of this product.
+   */
   def description: String
 
   /** Service entitlement number (SEN) is the
-    * add-on license id. Only included during
-    * installation of a paid add-on.
-    *
-    * @return Add-on license id if this is a paid add-on.
-    */
+   * app license id. Only included during
+   * installation of a paid app.
+   *
+   * @return App license id if this is a paid app.
+   */
+  @deprecated("No replacement")
   def serviceEntitlementNumber: Option[String]
 
-  /** Indicates if the add-on is currently
-    * installed on the host. Upon uninstallation,
-    * the value of this flag will be set to false.
-    *
-    * @return Installation status for this add-on.
-    */
+  /**
+   * License entitlement ID is the app license ID.
+   *
+   * This attribute will only be included during installation of a paid app.
+   *
+   * @return App entitlement ID if this is a paid app.
+   */
+  def entitlementId: Option[String]
+
+  /**
+   * License entitlement number is the app license number.
+   *
+   * This attribute will only be included during installation of a paid app.
+   *
+   * @return App entitlement number if this is a paid app.
+   */
+  def entitlementNumber: Option[String]
+
+  /** Indicates if the app is currently
+   * installed on the host. Upon uninstallation,
+   * the value of this flag will be set to false.
+   *
+   * @return Installation status for this app.
+   */
   def installed: Boolean
 
   /** Uninstalls this host by setting the installed field to false.
-    *
-    * @return A new version of this host with the installed field set to false.
-    */
+   *
+   * @return A new version of this host with the installed field set to false.
+   */
   def uninstalled: AtlassianHost
 }

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/DefaultAtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/DefaultAtlassianHost.scala
@@ -6,15 +6,16 @@ import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
   */
 case class DefaultAtlassianHost(clientKey: ClientKey,
                                 key: String,
-                                publicKey: String,
                                 oauthClientId: Option[String],
                                 sharedSecret: String,
-                                serverVersion: String,
-                                pluginsVersion: String,
                                 baseUrl: String,
+                                displayUrl: String,
+                                displayUrlServicedeskHelpCenter: String,
                                 productType: String,
                                 description: String,
                                 serviceEntitlementNumber: Option[String],
+                                entitlementId: Option[String],
+                                entitlementNumber: Option[String],
                                 installed: Boolean) extends AtlassianHost {
 
   override def uninstalled: AtlassianHost = copy(installed = false)

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/repositories/AtlassianHostRepository.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/repositories/AtlassianHostRepository.scala
@@ -20,13 +20,6 @@ trait AtlassianHostRepository {
     */
   def findByClientKey(clientKey: ClientKey): Future[Option[AtlassianHost]]
 
-  /** Tries to find the host with the given instance URL.
-    *
-    * @param instanceUrl Atlassian Connect host instance URL.
-    * @return Atlassian Connect host, if one is found.
-    */
-  def findByBaseUrl(instanceUrl: String): Future[Option[AtlassianHost]]
-
   /** Saves the given Atlassian Connect host.
     *
     * @param host Atlassian Connect host to store.

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/AtlassianConnectProperties.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/AtlassianConnectProperties.scala
@@ -13,10 +13,6 @@ import play.api.Configuration
   */
 @Singleton
 class AtlassianConnectProperties @Inject()(config: Configuration) {
-
-  lazy val allowReinstallMissingHost: Boolean =
-    atlassianConnectConfig.get[Boolean]("allowReinstallMissingHost")
-
   /**
     * Expiration time for JSON Web Tokens in seconds.
     */

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
@@ -18,15 +18,16 @@ object Implicits {
     DefaultAtlassianHost(
       e.clientKey,
       e.key,
-      e.publicKey,
       e.oauthClientId,
       e.sharedSecret,
-      e.serverVersion,
-      e.pluginsVersion,
       e.baseUrl,
+      e.displayUrl,
+      e.displayUrlServicedeskHelpCenter,
       e.productType,
       e.description,
       e.serviceEntitlementNumber,
+      e.entitlementId,
+      e.entitlementNumber,
       installed = true
     )
 

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/LifecycleEvent.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/LifecycleEvent.scala
@@ -7,97 +7,51 @@ sealed trait LifecycleEvent {
   val eventType: String
   val key: String
   val clientKey: String
-  val publicKey: String
   val oauthClientId: Option[String]
-  val serverVersion: String
-  val pluginsVersion: String
   val baseUrl: String
+  val displayUrl: String
+  val displayUrlServicedeskHelpCenter: String
   val productType: String
   val description: String
   val serviceEntitlementNumber: Option[String]
+  val entitlementId: Option[String]
+  val entitlementNumber: Option[String]
 }
 
 /**
-  * Installed lifecycle event of Atlassian Connect add-on.
-  *
-  * @param eventType                Lifecycle event type
-  * @param key                      Add-on key that was installed into the
-  *                                 Atlassian Product, as it appears in your
-  *                                 add-on's descriptor.
-  * @param clientKey                Identifying key for the Atlassian product
-  *                                 instance that the add-on was installed into.
-  * @param publicKey                Public key for this Atlassian product
-  *                                 instance.
-  * @param oauthClientId            OAuth 2.0 client ID for the add-on used
-  *                                 for OAuth 2.0 - JWT Bearer token
-  *                                 authorization grant type.
-  * @param sharedSecret             Secret to sign outgoing JWT tokens and
-  *                                 validate incoming JWT tokens. Only sent
-  *                                 on the installed event.
-  * @param serverVersion            Host product's version.
-  * @param pluginsVersion           Semver compliant version of Atlassian
-  *                                 Connect which is running on the host server.
-  * @param baseUrl                  URL prefix for this Atlassian product
-  *                                 instance.
-  * @param productType              Identifies the category of Atlassian
-  *                                 product, e.g. jira or confluence.
-  * @param description              Host product description.
-  * @param serviceEntitlementNumber Service entitlement number (SEN) is the
-  *                                 add-on license id. Only included during
-  *                                 installation of a paid add-on.
+  * Installed lifecycle event of Atlassian Connect app.
   */
 case class InstalledEvent(
     override val eventType: String,
     override val key: String,
     override val clientKey: String,
-    override val publicKey: String,
     override val oauthClientId: Option[String],
     sharedSecret: String,
-    override val serverVersion: String,
-    override val pluginsVersion: String,
     override val baseUrl: String,
+    override val displayUrl: String,
+    override val displayUrlServicedeskHelpCenter: String,
     override val productType: String,
     override val description: String,
-    override val serviceEntitlementNumber: Option[String])
+    override val serviceEntitlementNumber: Option[String],
+    override val entitlementId: Option[String],
+    override val entitlementNumber: Option[String])
     extends LifecycleEvent
 
 /**
   * Generic lifecycle event for all lifecycle actions other than installed event.
   * This event specifically does not contain the shared secret initially
   * provided in the installed event.
-  *
-  * @param eventType                Lifecycle event type
-  * @param key                      Add-on key that was installed into the
-  *                                 Atlassian Product, as it appears in your
-  *                                 add-on's descriptor.
-  * @param clientKey                Identifying key for the Atlassian product
-  *                                 instance that the add-on was installed into.
-  * @param publicKey                Public key for this Atlassian product
-  *                                 instance.
-  * @param oauthClientId            OAuth 2.0 client ID for the add-on used
-  *                                 for OAuth 2.0 - JWT Bearer token
-  *                                 authorization grant type.
-  * @param serverVersion            Host product's version.
-  * @param pluginsVersion           Semver compliant version of Atlassian
-  *                                 Connect which is running on the host server.
-  * @param baseUrl                  URL prefix for this Atlassian product
-  *                                 instance.
-  * @param productType              Identifies the category of Atlassian
-  *                                 product, e.g. jira or confluence.
-  * @param description              Host product description.
-  * @param serviceEntitlementNumber Service entitlement number (SEN) is the
-  *                                 add-on license id. Only included during
-  *                                 installation of a paid add-on.
   */
 case class GenericEvent(override val eventType: String,
                         override val key: String,
                         override val clientKey: String,
-                        override val publicKey: String,
                         override val oauthClientId: Option[String],
-                        override val serverVersion: String,
-                        override val pluginsVersion: String,
                         override val baseUrl: String,
+                        override val displayUrl: String,
+                        override val displayUrlServicedeskHelpCenter: String,
                         override val productType: String,
                         override val description: String,
-                        override val serviceEntitlementNumber: Option[String])
+                        override val serviceEntitlementNumber: Option[String],
+                        override val entitlementId: Option[String],
+                        override val entitlementNumber: Option[String])
     extends LifecycleEvent

--- a/modules/core/conf/reference.conf
+++ b/modules/core/conf/reference.conf
@@ -1,7 +1,5 @@
 atlassian.connect {
   jwtExpirationTime = 180
-  allowReinstallMissingHost = false
-  allowReinstallMissingHost = ${?AC_ALLOW_REINSTALL_MISSING_HOST}
   publicKeyHostBaseUrl = "https://connect-install-keys.atlassian.com"
 }
 

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
@@ -14,15 +14,16 @@ trait AtlassianHostGen extends SecurityContextGen {
       DefaultAtlassianHost(
         securityContext.clientKey,
         securityContext.key,
-        securityContext.publicKey,
         securityContext.oauthClientId,
         securityContext.sharedSecret,
-        securityContext.serverVersion,
-        securityContext.pluginsVersion,
         securityContext.baseUrl,
+        securityContext.displayUrl,
+        securityContext.displayUrlServicedeskHelpCenter,
         securityContext.productType,
         securityContext.description,
         securityContext.serviceEntitlementNumber,
+        securityContext.entitlementId,
+        securityContext.entitlementNumber,
         installed
       )
     }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/LifecycleEventGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/LifecycleEventGen.scala
@@ -18,15 +18,16 @@ trait LifecycleEventGen extends SecurityContextGen {
         eventType,
         securityContext.key,
         securityContext.clientKey,
-        securityContext.publicKey,
         securityContext.oauthClientId,
         securityContext.sharedSecret,
-        securityContext.serverVersion,
-        securityContext.pluginsVersion,
         securityContext.baseUrl,
+        securityContext.displayUrl,
+        securityContext.displayUrlServicedeskHelpCenter,
         securityContext.productType,
         securityContext.description,
-        securityContext.serviceEntitlementNumber
+        securityContext.serviceEntitlementNumber,
+        securityContext.entitlementId,
+        securityContext.entitlementNumber
       )
 
   def genericEventTypeGen: Gen[String] =
@@ -41,14 +42,15 @@ trait LifecycleEventGen extends SecurityContextGen {
         eventType,
         securityContext.key,
         securityContext.clientKey,
-        securityContext.publicKey,
         securityContext.oauthClientId,
-        securityContext.serverVersion,
-        securityContext.pluginsVersion,
         securityContext.baseUrl,
+        securityContext.displayUrl,
+        securityContext.displayUrlServicedeskHelpCenter,
         securityContext.productType,
         securityContext.description,
-        securityContext.serviceEntitlementNumber
+        securityContext.serviceEntitlementNumber,
+        securityContext.entitlementId,
+        securityContext.entitlementNumber
       )
 
 }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
@@ -6,22 +6,23 @@ import org.scalacheck.Gen._
 
 case class SecurityContext(key: String,
                            clientKey: ClientKey,
-                           publicKey: String,
                            oauthClientId: Option[String],
                            sharedSecret: String,
-                           serverVersion: String,
-                           pluginsVersion: String,
                            baseUrl: String,
+                           displayUrl: String,
+                           displayUrlServicedeskHelpCenter: String,
                            productType: String,
                            description: String,
-                           serviceEntitlementNumber: Option[String])
+                           serviceEntitlementNumber: Option[String],
+                           entitlementId: Option[String],
+                           entitlementNumber: Option[String])
 
 /**
-  * Security context generator generates a security context as provided in the
-  * Atlassian Connect installed event. It can be used to generate objects of
-  * type [[io.toolsplus.atlassian.connect.play.models.LifecycleEvent]] or
-  * [[io.toolsplus.atlassian.connect.play.api.models.AtlassianHost]].
-  */
+ * Security context generator generates a security context as provided in the
+ * Atlassian Connect installed event. It can be used to generate objects of
+ * type [[io.toolsplus.atlassian.connect.play.models.LifecycleEvent]] or
+ * [[io.toolsplus.atlassian.connect.play.api.models.AtlassianHost]].
+ */
 trait SecurityContextGen {
 
   def alphaNumStr: Gen[String] =
@@ -29,37 +30,35 @@ trait SecurityContextGen {
 
   def clientKeyGen: Gen[ClientKey] = alphaNumStr
 
-  def pluginVersionGen: Gen[String] =
-    listOfN(3, posNum[Int]).map(n => n.mkString("."))
-
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
-  def hostBaseUrlGen: Gen[String] =  alphaStr.suchThat(_.nonEmpty).map(hostName => s"https://$hostName.atlassian.net")
+  def hostBaseUrlGen: Gen[String] = alphaStr.suchThat(_.nonEmpty).map(hostName => s"https://$hostName.atlassian.net")
 
-  def securityContextGen: Gen[SecurityContext]=
+  def securityContextGen: Gen[SecurityContext] =
     for {
       key <- alphaStr
       clientKey <- clientKeyGen
-      publicKey <- alphaNumStr
       oauthClientId <- option(alphaNumStr)
       sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
-      serverVersion <- numStr
-      pluginsVersion <- pluginVersionGen
       baseUrl <- hostBaseUrlGen
       productType <- productTypeGen
       description <- alphaStr
       serviceEntitlementNumber <- option(numStr)
+      entitlementId <- option(alphaNumStr)
+      entitlementNumber <- option(alphaNumStr)
+
     } yield
       SecurityContext(key,
-       clientKey,
-       publicKey,
-       oauthClientId,
-       sharedSecret,
-       serverVersion,
-       pluginsVersion,
+        clientKey,
+        oauthClientId,
+        sharedSecret,
         baseUrl,
-       productType,
-       description,
-       serviceEntitlementNumber)
+        baseUrl,
+        baseUrl,
+        productType,
+        description,
+        serviceEntitlementNumber,
+        entitlementId,
+        entitlementNumber)
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.4.3-SNAPSHOT"
+ThisBuild / version := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
- add the `entitlementNumber` and `entitlementId` fields to the framework lifecycle payload
- add missing `displayUrl` and `displayUrlServicedeskHelpCenter` to `AtlassianHost` model
- remove deprecated `publicKey` field from the `AtlassianHost` model
- remove deprecated `serverVersion` and `pluginsVersion` fields from the `AtlassianHost` model
- remove `findByBaseUrl` method from `AtlassianHostRepository`
- remove `allowReinstallMissingHost` property from `AtlassianConnectProperties` as it is not used anymore anywhere