### PR TITLE
Add sttp backend to send requests authenticated as app

### DIFF
--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/AtlassianHostUriResolver.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/AtlassianHostUriResolver.scala
@@ -1,4 +1,4 @@
-package io.toolsplus.atlassian.connect.play.ws
+package io.toolsplus.atlassian.connect.play.auth.jwt.symmetric
 
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
 

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/JwtGenerator.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/JwtGenerator.scala
@@ -5,7 +5,6 @@ import io.toolsplus.atlassian.connect.play.api.models.{AppProperties, AtlassianH
 import io.toolsplus.atlassian.connect.play.auth.jwt.CanonicalUriHttpRequest
 import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator._
 import io.toolsplus.atlassian.connect.play.models.AtlassianConnectProperties
-import io.toolsplus.atlassian.connect.play.ws.AtlassianHostUriResolver
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import io.toolsplus.atlassian.jwt.{HttpRequestCanonicalizer, JwtBuilder}
 import play.api.Logger

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackend.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackend.scala
@@ -1,0 +1,106 @@
+package io.toolsplus.atlassian.connect.play.request.sttp.jwt
+
+import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator
+import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend.atlassianHostTagKey
+import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
+import sttp.capabilities.Effect
+import sttp.client3.{
+  DelegateSttpBackend,
+  Identity,
+  Request,
+  RequestT,
+  Response,
+  SttpBackend,
+  UriContext
+}
+import sttp.monad.MonadError
+import sttp.monad.syntax._
+
+/**
+  * Sttp backend that authenticates Atlassian host requests as the app.
+  *
+  * The app must specify the authentication type `jwt` in its app descriptor.
+  *
+  * For the backend to sign requests, the request must be associated with a `AtlassianHost` as follows:
+  * {{{
+  * import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend._
+  *
+  * class MyJiraHttpClient @Inject()(sttpBackend: SttpBackend[Future, Any]) {
+  *
+  *   def fetchIssue(issueKey: String)(implicit host: AtlassianHost) = {
+  *      basicRequest.withAtlassianHost(host).get(s"/rest/api/2/issue/{issueKey}").send(sttpBackend)
+  *   }
+  * }
+  * }}}
+  */
+final class JwtSignatureSttpBackend[F[_], P](
+    delegate: SttpBackend[F, P],
+    jwtGenerator: JwtGenerator,
+) extends DelegateSttpBackend(delegate) {
+  implicit val F: MonadError[F] = delegate.responseMonad
+
+  override def send[T, R >: P with Effect[F]](
+      request: Request[T, R]): F[Response[T]] =
+    for {
+      host <- extractHost(request)
+      absoluteUriRequest = ensureAbsoluteRequestUrl(request, host)
+      jwt <- generateJwt(absoluteUriRequest, host)
+      response <- delegate.send(
+        absoluteUriRequest
+          .header("Authorization", s"JWT $jwt")
+          .header("User-Agent", "atlassian-connect-play")
+      )
+    } yield response
+
+  private def extractHost[T, R >: P with Effect[F]](
+      request: Request[T, R]): F[AtlassianHost] =
+    request.tag(atlassianHostTagKey) match {
+      case Some(host) =>
+        host match {
+          case h: AtlassianHost => F.unit(h)
+          case h =>
+            F.error(new Exception(
+              s"Failed to extract Atlassian host from request: Invalid host type '${h.getClass.getName}', expected '${classOf[
+                AtlassianHost].getName}'"))
+        }
+      case None =>
+        F.error(new Exception(
+          "Failed to extract Atlassian host from request: No host configured. Use `request.tag(\"ATLASSIAN_HOST\", host)` to associate a request to a host"))
+    }
+
+  private def generateJwt[T, R >: P with Effect[F]](
+      request: Request[T, R],
+      host: AtlassianHost): F[RawJwt] = {
+    jwtGenerator.createJwtToken(request.method.toString,
+                                request.uri.toJavaUri,
+                                host) match {
+      case Right(jwt) => F.unit(jwt)
+      case Left(error) =>
+        F.error(new Exception(s"Unexpected JWT error: ${error.message}"))
+    }
+  }
+
+  private def ensureAbsoluteRequestUrl[T, R >: P with Effect[F]](
+      request: Request[T, R],
+      host: AtlassianHost): Request[T, R] = {
+    if (request.uri.isAbsolute) {
+      request
+    } else {
+      val absoluteUri = uri"${host.baseUrl}"
+        .withPath(request.uri.path)
+        .withParams(request.uri.params)
+        .fragment(request.uri.fragment)
+      request.copy[Identity, T, R](uri = absoluteUri)
+    }
+  }
+}
+
+object JwtSignatureSttpBackend {
+  val atlassianHostTagKey = "ATLASSIAN_HOST"
+
+  implicit class RequestTExtensions[U[_], T, -R](r: RequestT[U, T, R]) {
+    def withAtlassianHost(host: AtlassianHost): RequestT[U, T, R] =
+      r.tag(atlassianHostTagKey, host)
+  }
+}

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/request/ws/PlayWsAtlassianConnectHttpClient.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/request/ws/PlayWsAtlassianConnectHttpClient.scala
@@ -1,10 +1,10 @@
-package io.toolsplus.atlassian.connect.play.ws
+package io.toolsplus.atlassian.connect.play.request.ws
 
 import java.net.URI
 import io.lemonlabs.uri.Url
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
 import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator
-import io.toolsplus.atlassian.connect.play.ws.jwt.JwtSignatureCalculator
+import io.toolsplus.atlassian.connect.play.request.ws.jwt.JwtSignatureCalculator
 
 import javax.inject.Inject
 import play.api.libs.ws.{WSClient, WSRequest, WSSignatureCalculator}
@@ -24,8 +24,8 @@ import play.api.libs.ws.{WSClient, WSRequest, WSSignatureCalculator}
   * }
   * }}}
   */
-class AtlassianConnectHttpClient @Inject()(ws: WSClient,
-                                           jwtGenerator: JwtGenerator) {
+class PlayWsAtlassianConnectHttpClient @Inject()(ws: WSClient,
+                                                 jwtGenerator: JwtGenerator) {
 
   def authenticatedAsAddon(url: String)(
       implicit host: AtlassianHost): WSRequest =

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/request/ws/jwt/JwtSignatureCalculator.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/request/ws/jwt/JwtSignatureCalculator.scala
@@ -1,4 +1,4 @@
-package io.toolsplus.atlassian.connect.play.ws.jwt
+package io.toolsplus.atlassian.connect.play.request.ws.jwt
 
 import java.net.URI
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/AtlassianHostUriResolverSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/auth/jwt/symmetric/AtlassianHostUriResolverSpec.scala
@@ -1,4 +1,4 @@
-package io.toolsplus.atlassian.connect.play.ws
+package io.toolsplus.atlassian.connect.play.auth.jwt.symmetric
 
 import io.toolsplus.atlassian.connect.play.TestSpec
 import io.toolsplus.atlassian.connect.play.api.repositories.AtlassianHostRepository

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
@@ -18,11 +18,11 @@ case class SecurityContext(key: String,
                            entitlementNumber: Option[String])
 
 /**
- * Security context generator generates a security context as provided in the
- * Atlassian Connect installed event. It can be used to generate objects of
- * type [[io.toolsplus.atlassian.connect.play.models.LifecycleEvent]] or
- * [[io.toolsplus.atlassian.connect.play.api.models.AtlassianHost]].
- */
+  * Security context generator generates a security context as provided in the
+  * Atlassian Connect installed event. It can be used to generate objects of
+  * type [[io.toolsplus.atlassian.connect.play.models.LifecycleEvent]] or
+  * [[io.toolsplus.atlassian.connect.play.api.models.AtlassianHost]].
+  */
 trait SecurityContextGen {
 
   def alphaNumStr: Gen[String] =
@@ -32,7 +32,14 @@ trait SecurityContextGen {
 
   def productTypeGen: Gen[String] = oneOf("jira", "confluence")
 
-  def hostBaseUrlGen: Gen[String] = alphaStr.suchThat(_.nonEmpty).map(hostName => s"https://$hostName.atlassian.net")
+  def hostBaseUrlGen: Gen[String] =
+    for {
+      n <- Gen.choose(10, 30)
+      hostUrl <- Gen
+        .listOfN(n, alphaChar)
+        .map(_.mkString)
+        .map(hostName => s"https://$hostName.atlassian.net")
+    } yield hostUrl
 
   def securityContextGen: Gen[SecurityContext] =
     for {
@@ -49,16 +56,16 @@ trait SecurityContextGen {
 
     } yield
       SecurityContext(key,
-        clientKey,
-        oauthClientId,
-        sharedSecret,
-        baseUrl,
-        baseUrl,
-        baseUrl,
-        productType,
-        description,
-        serviceEntitlementNumber,
-        entitlementId,
-        entitlementNumber)
+                      clientKey,
+                      oauthClientId,
+                      sharedSecret,
+                      baseUrl,
+                      baseUrl,
+                      baseUrl,
+                      productType,
+                      description,
+                      serviceEntitlementNumber,
+                      entitlementId,
+                      entitlementNumber)
 
 }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackendSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackendSpec.scala
@@ -1,0 +1,140 @@
+package io.toolsplus.atlassian.connect.play.request.sttp.jwt
+
+import io.toolsplus.atlassian.connect.play.TestSpec
+import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator
+import io.toolsplus.atlassian.connect.play.models.{
+  AtlassianConnectProperties,
+  PlayAddonProperties
+}
+import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend.{
+  RequestTExtensions,
+  atlassianHostTagKey
+}
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
+import sttp.client3.testing.{RecordingSttpBackend, SttpBackendStub}
+import sttp.client3.{Response, UriContext, basicRequest}
+import sttp.model.StatusCode._
+import sttp.model.Uri
+
+import scala.concurrent.Future
+
+class JwtSignatureSttpBackendSpec
+    extends TestSpec
+    with ScalaFutures
+    with OptionValues
+    with GuiceOneAppPerSuite {
+
+  val relativeTestUrl: Uri = uri"/rest/api/2/issue/1"
+
+  val config: Configuration = app.configuration
+  val addonProperties = new PlayAddonProperties(config)
+  val connectProperties = new AtlassianConnectProperties(config)
+
+  val jwtGenerator =
+    new JwtGenerator(addonProperties, connectProperties)
+
+  val ok: Response[String] = Response("", Ok)
+
+  val always200Backend: SttpBackendStub[Future, Any] =
+    SttpBackendStub.asynchronousFuture.whenAnyRequest.thenRespond(ok)
+
+  "Given a SttpBackend wrapped in JwtSignatureSttpBackend" when {
+
+    "sending a request without an associated host" should {
+      "fail with a host not configured message" in {
+        val backend: JwtSignatureSttpBackend[Future, Any] =
+          new JwtSignatureSttpBackend[Future, Any](always200Backend,
+                                                   jwtGenerator)
+        val response =
+          basicRequest.get(relativeTestUrl).send(backend)
+        whenReady(response.failed) { error =>
+          error.getMessage must startWith(
+            "Failed to extract Atlassian host from request: No host configured.")
+        }
+      }
+    }
+
+    "sending a request with an invalid host" should {
+      "fail with a invalid host message" in {
+        val backend: JwtSignatureSttpBackend[Future, Any] =
+          new JwtSignatureSttpBackend[Future, Any](always200Backend,
+                                                   jwtGenerator)
+        val response =
+          basicRequest
+            .tag(atlassianHostTagKey, "not-an-atlassian-host")
+            .get(relativeTestUrl)
+            .send(backend)
+        whenReady(response.failed) { error =>
+          error.getMessage must startWith(
+            "Failed to extract Atlassian host from request: Invalid host type")
+        }
+      }
+    }
+
+    "sending a request with a valid host" should {
+      "successfully sign the request to a relative URL" in {
+        forAll(atlassianHostGen) { host =>
+          val recordingBackend = new RecordingSttpBackend(always200Backend)
+          val backend: JwtSignatureSttpBackend[Future, Any] =
+            new JwtSignatureSttpBackend[Future, Any](recordingBackend,
+                                                     jwtGenerator)
+          val response =
+            basicRequest
+              .withAtlassianHost(host)
+              .get(relativeTestUrl)
+              .send(backend)
+          val result = await(response)
+          result.code mustBe Ok
+
+          recordingBackend.allInteractions.head._1
+            .header("Authorization")
+            .get must fullyMatch regex "^JWT .+"
+        }
+      }
+
+      "successfully sign the request to an absolute URL if the host matches" in {
+        forAll(atlassianHostGen) { host =>
+          val recordingBackend = new RecordingSttpBackend(always200Backend)
+          val backend: JwtSignatureSttpBackend[Future, Any] =
+            new JwtSignatureSttpBackend[Future, Any](recordingBackend,
+                                                     jwtGenerator)
+          val response =
+            basicRequest
+              .withAtlassianHost(host)
+              .get(uri"${host.baseUrl}".withPath(relativeTestUrl.path))
+              .send(backend)
+          val result = await(response)
+          result.code mustBe Ok
+
+          recordingBackend.allInteractions.head._1
+            .header("Authorization")
+            .get must fullyMatch regex "^JWT .+"
+        }
+      }
+
+      "fail to sign the request if the absolute URL host does not match the given host" in {
+        val backend: JwtSignatureSttpBackend[Future, Any] =
+          new JwtSignatureSttpBackend[Future, Any](always200Backend,
+                                                   jwtGenerator)
+        forAll(atlassianHostGen) { host =>
+          val response =
+            basicRequest
+              .withAtlassianHost(host)
+              .get(uri"https://mismatch-host-base-url.atlassian.net".withPath(
+                relativeTestUrl.path))
+              .send(backend)
+          whenReady(response.failed) { error =>
+            error.getMessage must startWith(
+              "Unexpected JWT error: The given URI is not under the base URL of the given host")
+          }
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/request/ws/PlayWsAtlassianConnectHttpClientSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/request/ws/PlayWsAtlassianConnectHttpClientSpec.scala
@@ -1,11 +1,12 @@
-package io.toolsplus.atlassian.connect.play.ws
+package io.toolsplus.atlassian.connect.play.request.ws
 
 import java.net.URI
 import akka.util.ByteString
 import io.toolsplus.atlassian.connect.play.TestSpec
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
 import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator
-import io.toolsplus.atlassian.connect.play.ws.jwt.JwtSignatureCalculator
+import io.toolsplus.atlassian.connect.play.request.ws.PlayWsAtlassianConnectHttpClient
+import io.toolsplus.atlassian.connect.play.request.ws.jwt.JwtSignatureCalculator
 import org.scalacheck.Shrink
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.HeaderNames.{AUTHORIZATION, USER_AGENT}
@@ -16,7 +17,7 @@ import play.api.test.{Helpers, TestServer, WsTestClient}
 
 import scala.concurrent.{Future, Promise}
 
-class AtlassianConnectHttpClientSpec extends TestSpec with GuiceOneAppPerSuite {
+class PlayWsAtlassianConnectHttpClientSpec extends TestSpec with GuiceOneAppPerSuite {
 
   val action: DefaultActionBuilder = app.injector.instanceOf[DefaultActionBuilder]
   val parser: PlayBodyParsers = app.injector.instanceOf[PlayBodyParsers]
@@ -30,7 +31,7 @@ class AtlassianConnectHttpClientSpec extends TestSpec with GuiceOneAppPerSuite {
 
       "successfully return a WSRequest with resolved host URL" in WsTestClient
         .withClient { client =>
-          val httpClient = new AtlassianConnectHttpClient(client, jwtGenerator)
+          val httpClient = new PlayWsAtlassianConnectHttpClient(client, jwtGenerator)
           forAll(rootRelativePathGen, atlassianHostGen) { (path, host) =>
             val absoluteRequestUri = URI.create(s"${host.baseUrl}$path")
             val request = httpClient.authenticatedAsAddon(path)(host)
@@ -52,7 +53,7 @@ class AtlassianConnectHttpClientSpec extends TestSpec with GuiceOneAppPerSuite {
               .returning(Right(credentials.rawJwt))
 
             val (request, _, _) = receiveRequest { hostUrl => wsClient =>
-              val httpClient = new AtlassianConnectHttpClient(wsClient, jwtGenerator)
+              val httpClient = new PlayWsAtlassianConnectHttpClient(wsClient, jwtGenerator)
 
               httpClient.authenticatedAsAddon(s"$hostUrl/$path")(host).get()
             }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
     Library.circeParser,
     Library.circePlay,
     Library.scalaUri,
+    Library.sttp,
     Library.scalaTest % "test",
     Library.scalaTestPlusScalaCheck % "test",
     Library.scalaTestPlusPlay % "test",
@@ -25,6 +26,7 @@ object Version {
   val circe = "0.14.5"
   val playCirce = "2814.4"
   val scalaUri = "4.0.3"
+  val sttp = "3.9.1"
   val scalaTest = "3.2.9"
   val scalaTestPlusPlay = "5.1.0"
   val scalaTestPlusScalaCheck = "3.2.9.0"
@@ -42,6 +44,7 @@ object Library {
   val circeParser = "io.circe" %% "circe-parser" % Version.circe
   val circePlay = "com.dripower" %% "play-circe" % Version.playCirce
   val scalaUri = "io.lemonlabs" %% "scala-uri" % Version.scalaUri
+  val sttp = "com.softwaremill.sttp.client3" %% "core" % Version.sttp
   val scalaTest = "org.scalatest" %% "scalatest" % Version.scalaTest
   val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % Version.scalaTestPlusScalaCheck
   val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % Version.scalaTestPlusPlay


### PR DESCRIPTION
- add sttp dependency to project
- add `JwtSignatureSttpBackend` to send sttp requests authenticated as app to provide an alterative to Play-WS
- rename `AtlassianConnectHttpClient` to `PlayWsAtlassianConnectHttpClient`