### PR TITLE
Connect on Forge

### DIFF
--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/AtlassianHost.scala
@@ -3,129 +3,138 @@ package io.toolsplus.atlassian.connect.play.api.models
 import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 
 /** An Atlassian host in which the app is or has been installed. Hosts are
- * stored in AtlassianHostRepository.
- *
- * During processing of a request from an Atlassian host, the details of the
- * host and of the user at the browser can be obtained from the [[AtlassianHostUser]].
- *
- * @see https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/#lifecycle-http-request-payload
- */
+  * stored in AtlassianHostRepository.
+  *
+  * During processing of a request from an Atlassian host, the details of the
+  * host and of the user at the browser can be obtained from the [[AtlassianHostUser]].
+  *
+  * @see https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/#lifecycle-http-request-payload
+  */
 trait AtlassianHost {
 
   /** Identifying key for the Atlassian product
-   * instance that the app was installed into.
-   *
-   * @return Client key for this product instance.
-   */
+    * instance that the app was installed into.
+    *
+    * @return Client key for this product instance.
+    */
   def clientKey: ClientKey
 
   /** App key that was installed into the
-   * Atlassian product, as it appears in your
-   * app's descriptor.
-   *
-   * @return App key for this app.
-   */
+    * Atlassian product, as it appears in your
+    * app's descriptor.
+    *
+    * @return App key for this app.
+    */
   def key: String
 
   /** OAuth 2.0 client ID for the app used
-   * for OAuth 2.0 - JWT Bearer token
-   * authorization grant type.
-   *
-   * @return OAuth 2.0 client id.
-   */
+    * for OAuth 2.0 - JWT Bearer token
+    * authorization grant type.
+    *
+    * @return OAuth 2.0 client id.
+    */
   def oauthClientId: Option[String]
 
+  /**
+    * Identifier for this host's Forge installation, if the host has migrated to Connect on Forge.
+    *
+    * This is also the ID that any remote storage should be keyed against.
+    *
+    * @return Forge installation id.
+    */
+  def installationId: Option[String]
+
   /** Secret to sign outgoing JWT tokens and
-   * validate incoming JWT tokens. Only sent
-   * on the installed event.
-   *
-   * @return Shared secret for this product instance.
-   */
+    * validate incoming JWT tokens. Only sent
+    * on the installed event.
+    *
+    * @return Shared secret for this product instance.
+    */
   def sharedSecret: String
 
   /** URL prefix for this Atlassian product
-   * instance.
-   *
-   * @return Base URL for this product instance.
-   */
+    * instance.
+    *
+    * @return Base URL for this product instance.
+    */
   def baseUrl: String
 
   /**
-   * If the Atlassian product instance has an associated custom domain, this is the URL through which users will
-   * access the product. Any links which an app renders server-side should use this as the prefix of the link.
-   * This ensures links are rendered in the same context as the remainder of the user's site. If a custom domain
-   * is not configured, this field will still be present but will be the same as the baseUrl.
-   *
-   * Note that API requests from your app should always use the baseUrl value.
-   *
-   * @return Custom domain URL if configured, app's base URL otherwise.
-   */
+    * If the Atlassian product instance has an associated custom domain, this is the URL through which users will
+    * access the product. Any links which an app renders server-side should use this as the prefix of the link.
+    * This ensures links are rendered in the same context as the remainder of the user's site. If a custom domain
+    * is not configured, this field will still be present but will be the same as the baseUrl.
+    *
+    * Note that API requests from your app should always use the baseUrl value.
+    *
+    * @return Custom domain URL if configured, app's base URL otherwise.
+    */
   def displayUrl: String
 
   /**
-   * If the Atlassian product instance has an associated custom domain for Jira Service Desk functionality, this is
-   * the URL for the Jira Service Desk Help Center. Any related links which an app renders server-side should use this
-   * as the prefix of the link.
-   * This ensures links are rendered in the same context as the user's Jira Service Desk. If a custom domain is not
-   * configured, this field will still be present but will be the same as the baseUrl.
-   *
-   * Note that API requests from your App should always use the baseUrl value.
-   *
-   * @return Custom domain URL for Jira Service Desk if configured, app's base URL otherwise.
-   */
+    * If the Atlassian product instance has an associated custom domain for Jira Service Desk functionality, this is
+    * the URL for the Jira Service Desk Help Center. Any related links which an app renders server-side should use this
+    * as the prefix of the link.
+    * This ensures links are rendered in the same context as the user's Jira Service Desk. If a custom domain is not
+    * configured, this field will still be present but will be the same as the baseUrl.
+    *
+    * Note that API requests from your App should always use the baseUrl value.
+    *
+    * @return Custom domain URL for Jira Service Desk if configured, app's base URL otherwise.
+    */
   def displayUrlServicedeskHelpCenter: String
 
   /** Identifies the category of Atlassian
-   * product, e.g. jira or confluence.
-   *
-   * @return Category of this product.
-   */
+    * product, e.g. jira or confluence.
+    *
+    * @return Category of this product.
+    */
   def productType: String
 
   /** Host product description.
-   *
-   * @return Description of this product.
-   */
+    *
+    * @return Description of this product.
+    */
   def description: String
 
   /** Service entitlement number (SEN) is the
-   * app license id. Only included during
-   * installation of a paid app.
-   *
-   * @return App license id if this is a paid app.
-   */
+    * app license id. Only included during
+    * installation of a paid app.
+    *
+    * @return App license id if this is a paid app.
+    */
   @deprecated("No replacement")
   def serviceEntitlementNumber: Option[String]
 
   /**
-   * License entitlement ID is the app license ID.
-   *
-   * This attribute will only be included during installation of a paid app.
-   *
-   * @return App entitlement ID if this is a paid app.
-   */
+    * License entitlement ID is the app license ID.
+    *
+    * This attribute will only be included during installation of a paid app.
+    *
+    * @return App entitlement ID if this is a paid app.
+    */
   def entitlementId: Option[String]
 
   /**
-   * License entitlement number is the app license number.
-   *
-   * This attribute will only be included during installation of a paid app.
-   *
-   * @return App entitlement number if this is a paid app.
-   */
+    * License entitlement number is the app license number.
+    *
+    * This attribute will only be included during installation of a paid app.
+    *
+    * @return App entitlement number if this is a paid app.
+    */
   def entitlementNumber: Option[String]
 
   /** Indicates if the app is currently
-   * installed on the host. Upon uninstallation,
-   * the value of this flag will be set to false.
-   *
-   * @return Installation status for this app.
-   */
+    * installed on the host. Upon uninstallation,
+    * the value of this flag will be set to false.
+    *
+    * @return Installation status for this app.
+    */
   def installed: Boolean
 
   /** Uninstalls this host by setting the installed field to false.
-   *
-   * @return A new version of this host with the installed field set to false.
-   */
+    *
+    * @return A new version of this host with the installed field set to false.
+    */
   def uninstalled: AtlassianHost
 }

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/DefaultAtlassianHost.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/models/DefaultAtlassianHost.scala
@@ -7,6 +7,7 @@ import io.toolsplus.atlassian.connect.play.api.models.Predefined.ClientKey
 case class DefaultAtlassianHost(clientKey: ClientKey,
                                 key: String,
                                 oauthClientId: Option[String],
+                                installationId: Option[String],
                                 sharedSecret: String,
                                 baseUrl: String,
                                 displayUrl: String,

--- a/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/repositories/AtlassianHostRepository.scala
+++ b/modules/api/src/main/scala/io/toolsplus/atlassian/connect/play/api/repositories/AtlassianHostRepository.scala
@@ -20,6 +20,14 @@ trait AtlassianHostRepository {
     */
   def findByClientKey(clientKey: ClientKey): Future[Option[AtlassianHost]]
 
+  /** Tries to find the host with the given installation id.
+    *
+    * @param installationId Forge installation id of the Atlassian Connect host.
+    * @return Atlassian Connect host, if one is found.
+    */
+  def findByInstallationId(
+      installationId: String): Future[Option[AtlassianHost]]
+
   /** Saves the given Atlassian Connect host.
     *
     * @param host Atlassian Connect host to store.

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/Implicits.scala
@@ -1,6 +1,9 @@
 package io.toolsplus.atlassian.connect.play.models
 
-import io.toolsplus.atlassian.connect.play.api.models.{AtlassianHost, DefaultAtlassianHost}
+import io.toolsplus.atlassian.connect.play.api.models.{
+  AtlassianHost,
+  DefaultAtlassianHost
+}
 
 object Implicits {
 
@@ -19,6 +22,7 @@ object Implicits {
       e.clientKey,
       e.key,
       e.oauthClientId,
+      e.installationId,
       e.sharedSecret,
       e.baseUrl,
       e.displayUrl,

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/models/LifecycleEvent.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/models/LifecycleEvent.scala
@@ -26,6 +26,7 @@ case class InstalledEvent(
     override val key: String,
     override val clientKey: String,
     override val oauthClientId: Option[String],
+    installationId: Option[String],
     sharedSecret: String,
     override val baseUrl: String,
     override val displayUrl: String,

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/AtlassianHostRequest.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/AtlassianHostRequest.scala
@@ -1,0 +1,31 @@
+package io.toolsplus.atlassian.connect.play.request.sttp
+
+import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
+import sttp.client3.{Empty, RequestT, basicRequest}
+
+object AtlassianHostRequest {
+
+  private val atlassianHostTagKey = "ATLASSIAN_HOST"
+
+  def atlassianHostRequest(implicit host: AtlassianHost)
+  : RequestT[Empty, Either[String, String], Any] =
+    basicRequest.tag(atlassianHostTagKey, host)
+
+  implicit class RequestTExtensions[U[_], T, -R](r: RequestT[U, T, R]) {
+    def atlassianHost: Either[Exception, AtlassianHost] =
+      r.tag(atlassianHostTagKey) match {
+        case Some(host) =>
+          host match {
+            case h: AtlassianHost => Right(h)
+            case h =>
+              Left(new Exception(
+                s"Failed to extract Atlassian host from request: Invalid host type '${h.getClass.getName}', expected '${classOf[
+                  AtlassianHost].getName}'"))
+          }
+        case None =>
+          Left(new Exception(
+            "Failed to extract Atlassian host from request: No host configured. Use `atlassianHostRequest` to create a request that is associated with a host"))
+      }
+  }
+}
+

--- a/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackend.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackend.scala
@@ -2,18 +2,18 @@ package io.toolsplus.atlassian.connect.play.request.sttp.jwt
 
 import io.toolsplus.atlassian.connect.play.api.models.AtlassianHost
 import io.toolsplus.atlassian.connect.play.auth.jwt.symmetric.JwtGenerator
-import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend.atlassianHostTagKey
+import io.toolsplus.atlassian.connect.play.request.sttp.AtlassianHostRequest._
 import io.toolsplus.atlassian.jwt.api.Predef.RawJwt
 import sttp.capabilities.Effect
 import sttp.client3.{
   DelegateSttpBackend,
   Identity,
   Request,
-  RequestT,
   Response,
   SttpBackend,
   UriContext
 }
+import sttp.model.HeaderNames.{Authorization, UserAgent}
 import sttp.monad.MonadError
 import sttp.monad.syntax._
 
@@ -24,12 +24,12 @@ import sttp.monad.syntax._
   *
   * For the backend to sign requests, the request must be associated with a `AtlassianHost` as follows:
   * {{{
-  * import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend._
+  * import io.toolsplus.atlassian.connect.play.request.sttp.AtlassianHostRequest._
   *
   * class MyJiraHttpClient @Inject()(sttpBackend: SttpBackend[Future, Any]) {
   *
   *   def fetchIssue(issueKey: String)(implicit host: AtlassianHost) = {
-  *      basicRequest.withAtlassianHost(host).get(s"/rest/api/2/issue/{issueKey}").send(sttpBackend)
+  *      atlassianHostRequest.get(s"/rest/api/2/issue/{issueKey}").send(sttpBackend)
   *   }
   * }
   * }}}
@@ -48,25 +48,16 @@ final class JwtSignatureSttpBackend[F[_], P](
       jwt <- generateJwt(absoluteUriRequest, host)
       response <- delegate.send(
         absoluteUriRequest
-          .header("Authorization", s"JWT $jwt")
-          .header("User-Agent", "atlassian-connect-play")
+          .header(Authorization, s"JWT $jwt")
+          .header(UserAgent, "atlassian-connect-play")
       )
     } yield response
 
   private def extractHost[T, R >: P with Effect[F]](
       request: Request[T, R]): F[AtlassianHost] =
-    request.tag(atlassianHostTagKey) match {
-      case Some(host) =>
-        host match {
-          case h: AtlassianHost => F.unit(h)
-          case h =>
-            F.error(new Exception(
-              s"Failed to extract Atlassian host from request: Invalid host type '${h.getClass.getName}', expected '${classOf[
-                AtlassianHost].getName}'"))
-        }
-      case None =>
-        F.error(new Exception(
-          "Failed to extract Atlassian host from request: No host configured. Use `request.tag(\"ATLASSIAN_HOST\", host)` to associate a request to a host"))
+    request.atlassianHost match {
+      case Right(host) => F.unit(host)
+      case Left(error) => F.error(error)
     }
 
   private def generateJwt[T, R >: P with Effect[F]](
@@ -93,14 +84,5 @@ final class JwtSignatureSttpBackend[F[_], P](
         .fragment(request.uri.fragment)
       request.copy[Identity, T, R](uri = absoluteUri)
     }
-  }
-}
-
-object JwtSignatureSttpBackend {
-  val atlassianHostTagKey = "ATLASSIAN_HOST"
-
-  implicit class RequestTExtensions[U[_], T, -R](r: RequestT[U, T, R]) {
-    def withAtlassianHost(host: AtlassianHost): RequestT[U, T, R] =
-      r.tag(atlassianHostTagKey, host)
   }
 }

--- a/modules/core/conf/evolutions/default/1.sql
+++ b/modules/core/conf/evolutions/default/1.sql
@@ -4,6 +4,7 @@ CREATE TABLE atlassian_host (
   key                        VARCHAR                       NOT NULL,
   public_key                 VARCHAR                       NOT NULL,
   oauth_client_id            VARCHAR,
+  installation_id            VARCHAR,
   shared_secret              VARCHAR                       NOT NULL,
   server_version             VARCHAR                       NOT NULL,
   plugins_version            VARCHAR                       NOT NULL,
@@ -17,6 +18,8 @@ CREATE UNIQUE INDEX uq_ac_host_client_key
   ON atlassian_host (client_key);
 CREATE UNIQUE INDEX uq_ac_host_base_url
   ON atlassian_host (base_url);
+CREATE UNIQUE INDEX uq_ac_host_installation_id
+    ON atlassian_host (installation_id);
 
 # --- !Downs
 DROP TABLE atlassian_host;

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/AtlassianHostGen.scala
@@ -15,6 +15,7 @@ trait AtlassianHostGen extends SecurityContextGen {
         securityContext.clientKey,
         securityContext.key,
         securityContext.oauthClientId,
+        securityContext.installationId,
         securityContext.sharedSecret,
         securityContext.baseUrl,
         securityContext.displayUrl,

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/LifecycleEventGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/LifecycleEventGen.scala
@@ -1,9 +1,6 @@
 package io.toolsplus.atlassian.connect.play.generators
 
-import io.toolsplus.atlassian.connect.play.models.{
-  GenericEvent,
-  InstalledEvent
-}
+import io.toolsplus.atlassian.connect.play.models.{GenericEvent, InstalledEvent}
 import org.scalacheck.Gen
 import org.scalacheck.Gen._
 
@@ -19,6 +16,7 @@ trait LifecycleEventGen extends SecurityContextGen {
         securityContext.key,
         securityContext.clientKey,
         securityContext.oauthClientId,
+        securityContext.installationId,
         securityContext.sharedSecret,
         securityContext.baseUrl,
         securityContext.displayUrl,

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/generators/SecurityContextGen.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Gen._
 case class SecurityContext(key: String,
                            clientKey: ClientKey,
                            oauthClientId: Option[String],
+                           installationId: Option[String],
                            sharedSecret: String,
                            baseUrl: String,
                            displayUrl: String,
@@ -46,6 +47,7 @@ trait SecurityContextGen {
       key <- alphaStr
       clientKey <- clientKeyGen
       oauthClientId <- option(alphaNumStr)
+      installationId <- option(alphaNumStr)
       sharedSecret <- alphaNumStr.suchThat(s => s.length >= 32 && s.nonEmpty)
       baseUrl <- hostBaseUrlGen
       productType <- productTypeGen
@@ -55,17 +57,20 @@ trait SecurityContextGen {
       entitlementNumber <- option(alphaNumStr)
 
     } yield
-      SecurityContext(key,
-                      clientKey,
-                      oauthClientId,
-                      sharedSecret,
-                      baseUrl,
-                      baseUrl,
-                      baseUrl,
-                      productType,
-                      description,
-                      serviceEntitlementNumber,
-                      entitlementId,
-                      entitlementNumber)
+      SecurityContext(
+        key,
+        clientKey,
+        oauthClientId,
+        installationId,
+        sharedSecret,
+        baseUrl,
+        baseUrl,
+        baseUrl,
+        productType,
+        description,
+        serviceEntitlementNumber,
+        entitlementId,
+        entitlementNumber
+      )
 
 }

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackendSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/request/sttp/jwt/JwtSignatureSttpBackendSpec.scala
@@ -6,10 +6,7 @@ import io.toolsplus.atlassian.connect.play.models.{
   AtlassianConnectProperties,
   PlayAddonProperties
 }
-import io.toolsplus.atlassian.connect.play.request.sttp.jwt.JwtSignatureSttpBackend.{
-  RequestTExtensions,
-  atlassianHostTagKey
-}
+import io.toolsplus.atlassian.connect.play.request.sttp.AtlassianHostRequest.atlassianHostRequest
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -64,7 +61,7 @@ class JwtSignatureSttpBackendSpec
                                                    jwtGenerator)
         val response =
           basicRequest
-            .tag(atlassianHostTagKey, "not-an-atlassian-host")
+            .tag("ATLASSIAN_HOST", "not-an-atlassian-host")
             .get(relativeTestUrl)
             .send(backend)
         whenReady(response.failed) { error =>
@@ -82,8 +79,7 @@ class JwtSignatureSttpBackendSpec
             new JwtSignatureSttpBackend[Future, Any](recordingBackend,
                                                      jwtGenerator)
           val response =
-            basicRequest
-              .withAtlassianHost(host)
+            atlassianHostRequest(host)
               .get(relativeTestUrl)
               .send(backend)
           val result = await(response)
@@ -102,8 +98,7 @@ class JwtSignatureSttpBackendSpec
             new JwtSignatureSttpBackend[Future, Any](recordingBackend,
                                                      jwtGenerator)
           val response =
-            basicRequest
-              .withAtlassianHost(host)
+            atlassianHostRequest(host)
               .get(uri"${host.baseUrl}".withPath(relativeTestUrl.path))
               .send(backend)
           val result = await(response)
@@ -121,8 +116,7 @@ class JwtSignatureSttpBackendSpec
                                                    jwtGenerator)
         forAll(atlassianHostGen) { host =>
           val response =
-            basicRequest
-              .withAtlassianHost(host)
+            atlassianHostRequest(host)
               .get(uri"https://mismatch-host-base-url.atlassian.net".withPath(
                 relativeTestUrl.path))
               .send(backend)


### PR DESCRIPTION
- Update the framework to accept Connect-on-Forge installation payloads
- Update the installation payload to accept an optional Forge installation id
- update the `AtlassianHost` and all dependent models to include the optional Forge installation id
- update generators to generate the optional installation id field
- update the sample evolutions script to include the optional installation id field and add an index on the installation id field

fixes #75