### PR TITLE
Installation save order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
         run: sbt clean coverage test coverageReport
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Update the order in which installation payloads are saved by first saving the tenant and only then saving the Forge installation