### PR TITLE
Remove ForgeRemoteCredentials from ForgeRemoteContext

### DIFF
--- a/modules/core/app/io/toolsplus/atlassian/connect/play/auth/frc/ForgeRemoteContext.scala
+++ b/modules/core/app/io/toolsplus/atlassian/connect/play/auth/frc/ForgeRemoteContext.scala
@@ -2,8 +2,11 @@ package io.toolsplus.atlassian.connect.play.auth.frc
 
 import io.toolsplus.atlassian.connect.play.auth.frc.jwt.ForgeInvocationContext
 
-/**
-  * Verified Forge Remote context including the invocation context and the credentials associated with the call.
+/** Verified Forge Remote context including the invocation context and the
+  * credentials associated with the call.
   */
-case class ForgeRemoteContext(invocationContext: ForgeInvocationContext,
-                              credentials: ForgeRemoteCredentials)
+case class ForgeRemoteContext(
+    invocationContext: ForgeInvocationContext,
+    traceId: String,
+    spanId: String
+)

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/asymmetric/AssociateAtlassianHostUserActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/asymmetric/AssociateAtlassianHostUserActionSpec.scala
@@ -120,7 +120,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )
@@ -174,7 +175,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )
@@ -209,7 +211,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )
@@ -263,7 +266,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )
@@ -319,7 +323,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )
@@ -354,7 +359,8 @@ class AssociateAtlassianHostUserActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )

--- a/modules/core/test/io/toolsplus/atlassian/connect/play/actions/asymmetric/ForgeRemoteSignedForgeRemoteContextActionSpec.scala
+++ b/modules/core/test/io/toolsplus/atlassian/connect/play/actions/asymmetric/ForgeRemoteSignedForgeRemoteContextActionSpec.scala
@@ -119,7 +119,8 @@ class ForgeRemoteSignedForgeRemoteContextActionSpec
             ForgeRemoteContextRequest(
               ForgeRemoteContext(
                 fakeForgeInvocationContext,
-                forgeRemoteCredentials
+                forgeRemoteCredentials.traceId,
+                forgeRemoteCredentials.spanId,
               ),
               forgeRemoteRequest
             )


### PR DESCRIPTION
- Remove ForgeRemoteCredentials from ForgeRemoteContext
- Add trace and span IDs to the context
- Update tests

Closes #91